### PR TITLE
chore!(deps): Remove deprecated Apple platform targets

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
@@ -99,7 +99,6 @@ kotlin {
         watchosSimulatorArm64()
         watchosArm32()
         watchosArm64()
-        watchosX64()
         tvosSimulatorArm64()
         tvosArm64()
 
@@ -109,9 +108,7 @@ kotlin {
         // androidNativeArm64()
         // androidNativeX86()
         // androidNativeX64()
-        macosX64()
         iosX64()
-        tvosX64()
     }
 }
 

--- a/kt-schema-annotations/api/kt-schema-annotations.klib.api
+++ b/kt-schema-annotations/api/kt-schema-annotations.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kt-schema-json/api/kt-schema-json.klib.api
+++ b/kt-schema-json/api/kt-schema-json.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kt-schema-ksp-json/api/kt-schema-ksp-json.klib.api
+++ b/kt-schema-ksp-json/api/kt-schema-ksp-json.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true


### PR DESCRIPTION
## Description

Updated supported native target configuration to focus on the currently maintained platforms. Removed macosX64, tvosX64, watchosX64 targets since they are [depreceated](https://github.com/Kotlin/kotlinx.serialization/blob/master/buildSrc/src/main/kotlin/native-targets-conventions.gradle.kts) in Kotlinx-serialization