### PR TITLE
feat: add `jsonSchemaOf` convenience function

### DIFF
--- a/kt-schema-generator-json/api/kt-schema-generator-json.klib.api
+++ b/kt-schema-generator-json/api/kt-schema-generator-json.klib.api
@@ -33,6 +33,8 @@ final class me.kpavlov.kt.schema.generator.json.serialization/SerializationClass
     final object Companion { // me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator.Companion|null[0]
         final val Default // me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator.Companion.Default|{}Default[0]
             final fun <get-Default>(): me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator // me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator.Companion.Default.<get-Default>|<get-Default>(){}[0]
+
+        final inline fun <#A2: reified kotlin/Any?> jsonSchemaOf(me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator = ...): me.kpavlov.kt.schema.json/JsonSchema // me.kpavlov.kt.schema.generator.json.serialization/SerializationClassJsonSchemaGenerator.Companion.jsonSchemaOf|jsonSchemaOf(me.kpavlov.kt.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator){0§<kotlin.Any?>}[0]
     }
 }
 

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
@@ -1,11 +1,12 @@
 package me.kpavlov.kt.schema.generator.json.serialization
 
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 import me.kpavlov.kt.schema.generator.core.AbstractSchemaGenerator
 import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.TypeGraphToJsonSchemaTransformer
 import me.kpavlov.kt.schema.json.JsonSchema
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
 
 /**
@@ -51,5 +52,20 @@ public class SerializationClassJsonSchemaGenerator(
          * without requiring explicit configuration.
          */
         public val Default: SerializationClassJsonSchemaGenerator = SerializationClassJsonSchemaGenerator()
+
+        /**
+         * Generates a JSON Schema for the given `@Serializable` type [T], using the provided [generator].
+         *
+         * Example:
+         * ```kotlin
+         * @Serializable
+         * data class Person(val name: String, val age: Int)
+         *
+         * val schema = SerializationClassJsonSchemaGenerator.jsonSchemaOf<Person>()
+         * ```
+         */
+        public inline fun <reified T> jsonSchemaOf(
+            generator: SerializationClassJsonSchemaGenerator = SerializationClassJsonSchemaGenerator.Default,
+        ): JsonSchema = generator.generateSchema(serializer<T>().descriptor)
     }
 }

--- a/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
+++ b/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
@@ -13,6 +13,9 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import me.kpavlov.kt.schema.generator.core.defaultOpaqueTypeNames
+import me.kpavlov.kt.schema.generator.json.json
+import me.kpavlov.kt.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator.Companion.jsonSchemaOf
+import me.kpavlov.kt.schema.json.encodeToString
 import kotlin.test.Test
 
 class SerializationClassJsonSchemaGeneratorTest {
@@ -79,6 +82,37 @@ class SerializationClassJsonSchemaGeneratorTest {
                     },
                 ),
         )
+
+    @Test
+    fun `generates with default generator`() {
+        @Serializable
+        @SerialName("MyTestClass")
+        data class MyTestClass(
+            val prop: String,
+        )
+
+        val schema = jsonSchemaOf<MyTestClass>()
+        val schemaJson = schema.encodeToString(json)
+
+        schemaJson shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "MyTestClass",
+              "type": "object",
+              "properties": {
+                "prop": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "prop"
+              ]
+            }
+            """.trimIndent()
+    }
 
     @Test
     fun `Should generate JsonSchema for complex class`() {


### PR DESCRIPTION
Add a convenience `jsonSchemaOf<T>()` function around `SerializationClassJsonSchemaGenerator`, in the spirit of the `serializer<T>()` function provided by kotlinx-serialization.

It takes an optional `SerializationClassJsonSchemaGenerator` parameter which defaults to `SerializationClassJsonSchemaGenerator.Default`.

Cf. this discussion on Kotlin slack: https://kotlinlang.slack.com/archives/C0AN6QM3H16/p1775834702104669

Original PR by @ptitjes: https://github.com/Kotlin/kotlinx-schema/pull/318
