### PR TITLE
feat: java annotation processor (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # KT-Schema
 
-**Generate JSON schemas and LLM function calling schemas from Kotlin code — including classes you don't own.**
+**Generate JSON schemas and LLM function calling schemas from Kotlin and Java code — including classes you don't own.**
 
 > [!NOTE]
 > **kt-schema** is a fork of [kotlinx.schema](https://github.com/Kotlin/kotlinx-schema),
@@ -26,6 +26,7 @@
 Quick Links:
 
 - [KSP Configuration Guide](docs/ksp.md)
+- [Java Annotation Processor Guide](docs/apt.md)
 - [Serialization-Based Schema Generation](docs/serializable.md)
 - [Project Architecture](docs/architecture.md)
 
@@ -33,7 +34,8 @@ Quick Links:
 
 **Generation Modes:**
 
-- **Compile-time (KSP)**: Zero runtime overhead, multiplatform, for your annotated classes
+- **Compile-time (KSP)**: Zero runtime overhead, multiplatform, for your annotated Kotlin classes
+- **Compile-time (Java APT)**: Zero runtime overhead for plain Java records — no Kotlin required in your code
 - **Runtime (Reflection)**: JVM-only, for any class including third-party libraries
 - **Runtime (SerialDescriptor)**: Kotlin serializable classes, including open polymorphism via `SerializersModule`
 
@@ -151,19 +153,24 @@ This library solves three key challenges:
 
 ## Choosing Your Approach
 
-|                                   | 🔧 [KSP Processor](docs/ksp.md) | 📦 [Serialization-based](docs/serializable.md) | 🔍 [Runtime Reflection](#runtime-schema-generation) |
-|:----------------------------------|:-------------------------------:|:----------------------------------------------:|:---------------------------------------------------:|
-| **Platforms**                     |       JVM + Multiplatform       |              JVM + Multiplatform               |                      JVM only                       |
-| **When generated**                |          Compile-time           |                    Runtime                     |                       Runtime                       |
-| **Requires annotation processor** |            Yes (KSP)            |                       No                       |                         No                          |
-| **Class must be `@Serializable`** |               No                |                      Yes                       |                         No                          |
-| **Annotate class with `@Schema`** |            Required             |                  Not required                  |                    Not required                     |
-| **KDoc extracted to description** |                ✅                |                       ❌                        |                          ❌                          |
-| **Extract default values**        |                ❌                |                       ❌                        |                          ✅                          |
-| **Third-party classes**           |                ❌                |            ✅ (only `@Serializable`)            |                   ✅ any JVM class                   |
+|                                   | 🔧 [KSP Processor](docs/ksp.md) | ☕ [Java APT](docs/apt.md) | 📦 [Serialization-based](docs/serializable.md) | 🔍 [Runtime Reflection](#runtime-schema-generation) |
+|:----------------------------------|:-------------------------------:|:--------------------------:|:----------------------------------------------:|:---------------------------------------------------:|
+| **Platforms**                     |       JVM + Multiplatform       |          JVM only          |              JVM + Multiplatform               |                      JVM only                       |
+| **When generated**                |          Compile-time           |        Compile-time        |                    Runtime                     |                       Runtime                       |
+| **Requires annotation processor** |            Yes (KSP)            |          Yes (APT)         |                       No                       |                         No                          |
+| **Class must be `@Serializable`** |               No                |             No             |                      Yes                       |                         No                          |
+| **Annotate class with `@Schema`** |            Required             |    Not required¹           |                  Not required                  |                    Not required                     |
+| **KDoc extracted to description** |                ✅                |             ❌              |                       ❌                        |                          ❌                          |
+| **Extract default values**        |                ❌                |             ❌              |                       ❌                        |                          ✅                          |
+| **Third-party classes**           |                ❌                |             ❌              |            ✅ (only `@Serializable`)            |                   ✅ any JVM class                   |
+
+¹ with the `rootPackage` option — see [Java Annotation Processor Guide](docs/apt.md#triggering-schema-generation).
 
 - **[Pick KSP](docs/ksp.md)** when you own the classes, want zero runtime overhead, and target Multiplatform or need KDoc
 in your schema.
+
+- **[Pick Java APT](docs/apt.md)** when your code is plain Java (no Kotlin) and you want zero runtime overhead.
+Currently supports Java records only.
 
 - **[Pick Serialization-based](docs/serializable.md)** when your classes are already `@Serializable` and you need
 Multiplatform support without a build-time processor.

--- a/apt-integration-tests/build.gradle.kts
+++ b/apt-integration-tests/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+dependencies {
+    implementation(libs.jackson.annotations)
+    annotationProcessor(project(":kt-schema-apt"))
+
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.jackson.databind)
+    testImplementation(platform(libs.junit.bom))
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add(
+        "-Ame.kpavlov.kt.schema.rootPackage=me.kpavlov.kt.schema.apt.integration"
+    )
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 /**
  * Simple test model to verify plain (non-record) Java class schema generation.
  */
+@SuppressWarnings("unused")
 @JsonClassDescription("A company with a name and a founding year.")
 public class Company {
 

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
@@ -1,0 +1,22 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Simple test model to verify plain (non-record) Java class schema generation.
+ */
+@JsonClassDescription("A company with a name and a founding year.")
+public class Company {
+
+    @JsonPropertyDescription("Name of the company")
+    private final String name;
+
+    @JsonPropertyDescription("Year the company was founded")
+    private final int founded;
+
+    public Company(String name, int founded) {
+        this.name = name;
+        this.founded = founded;
+    }
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Person.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Person.java
@@ -1,0 +1,14 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Simple test model to verify basic Java annotation-processor schema generation.
+ */
+@JsonClassDescription("A person with a first and last name and age.")
+public record Person(
+        @JsonPropertyDescription("Given name of the person") String firstName,
+        @JsonPropertyDescription("Family name of the person") String lastName,
+        @JsonPropertyDescription("Age of the person in years") int age) {
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Product.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Product.java
@@ -1,0 +1,17 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Simple test model to verify Java interface schema generation.
+ */
+@JsonClassDescription("A product with a name and a price.")
+public interface Product {
+
+    @JsonPropertyDescription("Name of the product")
+    String getName();
+
+    @JsonPropertyDescription("Price of the product in cents")
+    int getPrice();
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/ClassSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/ClassSchemaTest.java
@@ -1,0 +1,58 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a plain
+ * (non-record) Java class selected by the configured {@code rootPackage} compiler option.
+ */
+class ClassSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Company.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldGenerateCompleteSchemaWithAllRequiredFields() throws IOException {
+        JsonNode actual = readGeneratedSchema();
+
+        // language=json
+        JsonNode expected = MAPPER.readTree("""
+                {
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Company",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the company"
+                    },
+                    "founded": {
+                      "type": "integer",
+                      "description": "Year the company was founded"
+                    }
+                  },
+                  "required": ["name", "founded"],
+                  "additionalProperties": false,
+                  "description": "A company with a name and a founding year."
+                }
+                """);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private JsonNode readGeneratedSchema() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            assertThat(input).as("generated schema resource: %s", RESOURCE_PATH).isNotNull();
+            return MAPPER.readTree(input);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
@@ -10,14 +10,13 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java record
- * selected by the configured {@code rootPackage} compiler option, not because it is
- * annotated with {@code @Schema}.
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a plain
+ * (non-record) Java class selected by the configured {@code rootPackage} compiler option.
  */
-class PersonSchemaTest {
+class CompanySchemaTest {
 
     private static final String RESOURCE_PATH =
-            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Company.json";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -27,26 +26,22 @@ class PersonSchemaTest {
 
         JsonNode expected = MAPPER.readTree("""
                 {
-                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Company",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "firstName": {
+                    "name": {
                       "type": "string",
-                      "description": "Given name of the person"
+                      "description": "Name of the company"
                     },
-                    "lastName": {
-                      "type": "string",
-                      "description": "Family name of the person"
-                    },
-                    "age": {
+                    "founded": {
                       "type": "integer",
-                      "description": "Age of the person in years"
+                      "description": "Year the company was founded"
                     }
                   },
-                  "required": ["firstName", "lastName", "age"],
+                  "required": ["name", "founded"],
                   "additionalProperties": false,
-                  "description": "A person with a first and last name and age."
+                  "description": "A company with a name and a founding year."
                 }
                 """);
 

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/InterfaceSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/InterfaceSchemaTest.java
@@ -10,14 +10,13 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java record
- * selected by the configured {@code rootPackage} compiler option, not because it is
- * annotated with {@code @Schema}.
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * interface selected by the configured {@code rootPackage} compiler option.
  */
-class PersonSchemaTest {
+class InterfaceSchemaTest {
 
     private static final String RESOURCE_PATH =
-            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Product.json";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -25,28 +24,25 @@ class PersonSchemaTest {
     void shouldGenerateCompleteSchemaWithAllRequiredFields() throws IOException {
         JsonNode actual = readGeneratedSchema();
 
+        // language=json
         JsonNode expected = MAPPER.readTree("""
                 {
-                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Product",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "firstName": {
+                    "name": {
                       "type": "string",
-                      "description": "Given name of the person"
+                      "description": "Name of the product"
                     },
-                    "lastName": {
-                      "type": "string",
-                      "description": "Family name of the person"
-                    },
-                    "age": {
+                    "price": {
                       "type": "integer",
-                      "description": "Age of the person in years"
+                      "description": "Price of the product in cents"
                     }
                   },
-                  "required": ["firstName", "lastName", "age"],
+                  "required": ["name", "price"],
                   "additionalProperties": false,
-                  "description": "A person with a first and last name and age."
+                  "description": "A product with a name and a price."
                 }
                 """);
 

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
@@ -1,0 +1,61 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a
+ * {@code @Schema}-annotated Java record.
+ */
+class PersonSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldGenerateCompleteSchemaWithAllRequiredFields() throws IOException {
+        JsonNode actual = readGeneratedSchema();
+
+        JsonNode expected = MAPPER.readTree("""
+                {
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "description": "Given name of the person"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "Family name of the person"
+                    },
+                    "age": {
+                      "type": "integer",
+                      "description": "Age of the person in years"
+                    }
+                  },
+                  "required": ["firstName", "lastName", "age"],
+                  "additionalProperties": false,
+                  "description": "A person with a first and last name and age."
+                }
+                """);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private JsonNode readGeneratedSchema() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            assertThat(input).as("generated schema resource: %s", RESOURCE_PATH).isNotNull();
+            return MAPPER.readTree(input);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/RecordSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/RecordSchemaTest.java
@@ -10,13 +10,14 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies the kt-schema-apt processor generates a JSON Schema resource for a plain
- * (non-record) Java class selected by the configured {@code rootPackage} compiler option.
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java record
+ * selected by the configured {@code rootPackage} compiler option, not because it is
+ * annotated with {@code @Schema}.
  */
-class CompanySchemaTest {
+class RecordSchemaTest {
 
     private static final String RESOURCE_PATH =
-            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Company.json";
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -24,24 +25,29 @@ class CompanySchemaTest {
     void shouldGenerateCompleteSchemaWithAllRequiredFields() throws IOException {
         JsonNode actual = readGeneratedSchema();
 
+        // language=json
         JsonNode expected = MAPPER.readTree("""
                 {
-                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Company",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "name": {
+                    "firstName": {
                       "type": "string",
-                      "description": "Name of the company"
+                      "description": "Given name of the person"
                     },
-                    "founded": {
+                    "lastName": {
+                      "type": "string",
+                      "description": "Family name of the person"
+                    },
+                    "age": {
                       "type": "integer",
-                      "description": "Year the company was founded"
+                      "description": "Age of the person in years"
                     }
                   },
-                  "required": ["name", "founded"],
+                  "required": ["firstName", "lastName", "age"],
                   "additionalProperties": false,
-                  "description": "A company with a name and a founding year."
+                  "description": "A person with a first and last name and age."
                 }
                 """);
 

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -15,8 +15,8 @@
 
 <!--- END -->
 
-Generate JSON Schema resources at compile time from plain Java records and classes using the `kt-schema-apt` JSR 269
-(`javax.annotation.processing`) processor — no Kotlin required in your own code.
+Generate JSON Schema resources at compile time from plain Java records, classes and interfaces using the
+`kt-schema-apt` JSR 269 (`javax.annotation.processing`) processor — no Kotlin required in your own code.
 
 ## Setup
 
@@ -69,8 +69,8 @@ dependencies {
 The processor picks up a Java type either of two ways — you don't need both:
 
 1. **Annotate the type with `@Schema`** (from `kt-schema-annotations`) — processed regardless of package.
-2. **Set the [`rootPackage`](#configuration-options) option** — every top-level `record` or `class` declared
-   under that package (and its sub-packages) is processed, `@Schema` or not.
+2. **Set the [`rootPackage`](#configuration-options) option** — every top-level `record`, `class` or `interface`
+   declared under that package (and its sub-packages) is processed, `@Schema` or not.
 
 ```java
 import me.kpavlov.kt.schema.Description;
@@ -107,7 +107,7 @@ public record Person(
 
 | Option        | Type     | Default | Description                                                                                                     |
 |:--------------|:---------|:--------|:------------------------------------------------------------------------------------------------------------------|
-| `rootPackage` | `String` | `null`  | Process every top-level `record` or `class` under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
+| `rootPackage` | `String` | `null`  | Process every top-level `record`, `class` or `interface` under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
 
 Set it as a javac `-A` compiler argument:
 
@@ -178,8 +178,10 @@ try (InputStream in = Person.class.getClassLoader()
 - Java `record`s — components map to required properties (Java records have no notion of optional/default
   values, so every component is required)
 - Plain Java `class`es — non-static fields map to required properties, treated the same way as records
+- Java `interface`s — no-arg methods map to required properties, named per the JavaBeans convention
+  (`getName()` → `name`, `isActive()` → `active`, and a bare `name()` accessor stays `name`)
 - `String`, boxed and primitive numeric/boolean types
-- Nested records/classes, emitted as `$ref`/`$defs` and deduplicated, same as KSP
+- Nested records/classes/interfaces, emitted as `$ref`/`$defs` and deduplicated, same as KSP
 
 Not yet supported: enums, sealed interfaces/classes, generics, and collections/maps. Processing an
 unsupported type fails the build with a descriptive error rather than emitting an incomplete schema.

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -15,7 +15,7 @@
 
 <!--- END -->
 
-Generate JSON Schema resources at compile time from plain Java classes using the `kt-schema-apt` JSR 269
+Generate JSON Schema resources at compile time from plain Java records and classes using the `kt-schema-apt` JSR 269
 (`javax.annotation.processing`) processor — no Kotlin required in your own code.
 
 ## Setup
@@ -69,8 +69,8 @@ dependencies {
 The processor picks up a Java type either of two ways — you don't need both:
 
 1. **Annotate the type with `@Schema`** (from `kt-schema-annotations`) — processed regardless of package.
-2. **Set the [`rootPackage`](#configuration-options) option** — every top-level type declared under that
-   package (and its sub-packages) is processed, `@Schema` or not.
+2. **Set the [`rootPackage`](#configuration-options) option** — every top-level `record` or `class` declared
+   under that package (and its sub-packages) is processed, `@Schema` or not.
 
 ```java
 import me.kpavlov.kt.schema.Description;
@@ -107,7 +107,7 @@ public record Person(
 
 | Option        | Type     | Default | Description                                                                                                     |
 |:--------------|:---------|:--------|:------------------------------------------------------------------------------------------------------------------|
-| `rootPackage` | `String` | `null`  | Process every top-level type under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
+| `rootPackage` | `String` | `null`  | Process every top-level `record` or `class` under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
 
 Set it as a javac `-A` compiler argument:
 
@@ -128,7 +128,7 @@ Unlike the KSP processor — which generates `KClass<T>.jsonSchemaString`/`.json
 `kt-schema-apt` has no Kotlin code to attach extension properties to. Instead, it writes one JSON Schema
 resource per processed type:
 
-```
+```text
 META-INF/kt-schema/schemas/<package-as-directories>/<ClassName>.json
 ```
 
@@ -177,12 +177,12 @@ try (InputStream in = Person.class.getClassLoader()
 
 - Java `record`s — components map to required properties (Java records have no notion of optional/default
   values, so every component is required)
+- Plain Java `class`es — non-static fields map to required properties, treated the same way as records
 - `String`, boxed and primitive numeric/boolean types
-- Nested records, emitted as `$ref`/`$defs` and deduplicated, same as KSP
+- Nested records/classes, emitted as `$ref`/`$defs` and deduplicated, same as KSP
 
-Not yet supported: enums, sealed interfaces/classes, generics, collections/maps, and ordinary (non-record)
-classes. Processing an unsupported type fails the build with a descriptive error rather than emitting an
-incomplete schema.
+Not yet supported: enums, sealed interfaces/classes, generics, and collections/maps. Processing an
+unsupported type fails the build with a descriptive error rather than emitting an incomplete schema.
 
 > [!NOTE]
 > Reference-typed components are always treated as non-nullable/required — there's no `@Nullable` support yet.

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -1,0 +1,195 @@
+# Java Annotation Processor
+
+**Table of contents**
+<!--- TOC -->
+
+* [Setup](#setup)
+  * [Maven](#maven)
+  * [Gradle (Java projects)](#gradle-java-projects)
+* [Triggering schema generation](#triggering-schema-generation)
+* [Configuration options](#configuration-options)
+* [Generated output](#generated-output)
+  * [Reading the resource at runtime](#reading-the-resource-at-runtime)
+* [Supported types](#supported-types)
+* [See Also](#see-also)
+
+<!--- END -->
+
+Generate JSON Schema resources at compile time from plain Java classes using the `kt-schema-apt` JSR 269
+(`javax.annotation.processing`) processor — no Kotlin required in your own code.
+
+## Setup
+
+### Maven
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>me.kpavlov.kt.schema</groupId>
+                <artifactId>kt-schema-apt</artifactId>
+                <version>${kt-schema.version}</version>
+            </path>
+        </annotationProcessorPaths>
+        <compilerArgs>
+            <arg>-Ame.kpavlov.kt.schema.rootPackage=com.example</arg>
+        </compilerArgs>
+    </configuration>
+</plugin>
+
+<!-- Only needed if you annotate types with @Schema/@Description directly -->
+<dependencies>
+    <dependency>
+        <groupId>me.kpavlov.kt.schema</groupId>
+        <artifactId>kt-schema-annotations</artifactId>
+        <version>${kt-schema.version}</version>
+    </dependency>
+</dependencies>
+```
+
+### Gradle (Java projects)
+
+```kotlin
+plugins {
+    java
+}
+
+dependencies {
+    annotationProcessor("me.kpavlov.kt.schema:kt-schema-apt:<version>")
+    // Only needed if you annotate types with @Schema/@Description directly:
+    implementation("me.kpavlov.kt.schema:kt-schema-annotations:<version>")
+}
+```
+
+## Triggering schema generation
+
+The processor picks up a Java type either of two ways — you don't need both:
+
+1. **Annotate the type with `@Schema`** (from `kt-schema-annotations`) — processed regardless of package.
+2. **Set the [`rootPackage`](#configuration-options) option** — every top-level type declared under that
+   package (and its sub-packages) is processed, `@Schema` or not.
+
+```java
+import me.kpavlov.kt.schema.Description;
+import me.kpavlov.kt.schema.Schema;
+
+@Description("A person with a first and last name and age.")
+@Schema
+public record Person(
+        @Description("Given name of the person") String firstName,
+        @Description("Family name of the person") String lastName,
+        @Description("Age of the person in years") int age) {
+}
+```
+
+With `rootPackage` configured, you can skip `kt-schema-annotations` entirely and reuse annotations you
+already depend on — for example Jackson's:
+
+```java
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+@JsonClassDescription("A person with a first and last name and age.")
+public record Person(
+        @JsonPropertyDescription("Given name of the person") String firstName,
+        @JsonPropertyDescription("Family name of the person") String lastName,
+        @JsonPropertyDescription("Age of the person in years") int age) {
+}
+```
+
+`kt-schema-apt` recognizes `@JsonPropertyDescription`/`@JsonClassDescription` out of the box — see
+[Multi-Framework Annotation Support](../README.md#multi-framework-annotation-support) for the full list.
+
+## Configuration options
+
+| Option        | Type     | Default | Description                                                                                                     |
+|:--------------|:---------|:--------|:------------------------------------------------------------------------------------------------------------------|
+| `rootPackage` | `String` | `null`  | Process every top-level type under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
+
+Set it as a javac `-A` compiler argument:
+
+```kotlin
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Ame.kpavlov.kt.schema.rootPackage=com.example")
+}
+```
+
+> [!NOTE]
+> `kt-schema-apt` is newer than the KSP processor and doesn't yet support all of its options.
+> `include`/`exclude` glob filtering, `withSchemaObject`, `visibility`, and `enabled` from
+> [the KSP processor](ksp.md) aren't implemented here yet.
+
+## Generated output
+
+Unlike the KSP processor — which generates `KClass<T>.jsonSchemaString`/`.jsonSchema` Kotlin extensions —
+`kt-schema-apt` has no Kotlin code to attach extension properties to. Instead, it writes one JSON Schema
+resource per processed type:
+
+```
+META-INF/kt-schema/schemas/<package-as-directories>/<ClassName>.json
+```
+
+For the `Person` record above, that's `META-INF/kt-schema/schemas/com/example/Person.json`:
+
+```json
+{
+  "$id": "com.example.Person",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "Given name of the person"
+    },
+    "lastName": {
+      "type": "string",
+      "description": "Family name of the person"
+    },
+    "age": {
+      "type": "integer",
+      "description": "Age of the person in years"
+    }
+  },
+  "required": ["firstName", "lastName", "age"],
+  "additionalProperties": false,
+  "description": "A person with a first and last name and age."
+}
+```
+
+This is the same [Draft 2020-12 JSON Schema model](../kt-schema-json) the KSP processor produces — both reuse
+the same `TypeGraphToJsonSchemaTransformer`, so `$id`/`$defs`/`$ref`/nullability handling is identical.
+
+### Reading the resource at runtime
+
+Read it like any other classpath resource:
+
+```java
+try (InputStream in = Person.class.getClassLoader()
+        .getResourceAsStream("META-INF/kt-schema/schemas/com/example/Person.json")) {
+    String schema = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+}
+```
+
+## Supported types
+
+- Java `record`s — components map to required properties (Java records have no notion of optional/default
+  values, so every component is required)
+- `String`, boxed and primitive numeric/boolean types
+- Nested records, emitted as `$ref`/`$defs` and deduplicated, same as KSP
+
+Not yet supported: enums, sealed interfaces/classes, generics, collections/maps, and ordinary (non-record)
+classes. Processing an unsupported type fails the build with a descriptive error rather than emitting an
+incomplete schema.
+
+> [!NOTE]
+> Reference-typed components are always treated as non-nullable/required — there's no `@Nullable` support yet.
+
+## See Also
+
+- [KSP Configuration Guide](ksp.md) — the Kotlin compile-time equivalent, with `KClass<T>.jsonSchemaString` extensions
+- [Annotation Reference](../README.md#using-schema-and-description-annotations) — `@Schema` and `@Description` usage
+- [Multi-Framework Annotation Support](../README.md#multi-framework-annotation-support) — Jackson, LangChain4j, Koog recognition
+- [Project Architecture](architecture.md) — how the shared IR and transformer pipeline works

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,11 +25,13 @@ graph LR
         Kotlin["Kotlin Classes<br/>@Schema annotated"]
         KSerializer["SerialDescriptor"]
         Java["Java Classes<br/>Third-party libs"]
+        JavaApt["Java Records<br/>@Schema or rootPackage"]
         Functions["Kotlin Functions"]
     end
 
     subgraph Introspectors["🔍 Stage 1: INTROSPECTORS"]
         KSP["KspSchemaIntrospector<br/><i>compile-time</i>"]
+        Apt["AptClassIntrospector<br/><i>compile-time</i>"]
         Reflect["ReflectionSchemaIntrospector<br/><i>runtime</i>"]
         Serialization["SerializationClassSchemaIntrospector<br/><i>runtime</i>"]
     end
@@ -49,16 +51,19 @@ graph LR
         JsonSchema["JsonSchema<br/>(@Serializable)"]
         JsonObj["JsonObject<br/>kotlinx.serialization"]
         JsonStr["JSON String<br/>Serialized schema"]
+        AptResource["Generated .json resource<br/>META-INF/kt-schema/schemas/..."]
         FuncSchema["FunctionCallingSchema<br/>(@Serializable)"]
     end
 
     Kotlin --> KSP
     KSerializer --> Serialization
     Java --> Reflect
+    JavaApt --> Apt
     Functions --> KSP
     Functions --> Reflect
 
     KSP --> TypeGraph
+    Apt --> TypeGraph
     Reflect --> TypeGraph
     Serialization --> TypeGraph
 
@@ -71,6 +76,7 @@ graph LR
     FuncSchema --> KtFunc
     JsonObj --> JsonStr
     JsonObj --> KtClass
+    JsonObj --> AptResource
 
     classDef sourceStyle fill:#e3f2fd,stroke:#1565c0,stroke-width:3px,color:#000
     classDef introspectorStyle fill:#fff3e0,stroke:#ef6c00,stroke-width:3px,color:#000
@@ -78,20 +84,20 @@ graph LR
     classDef transformStyle fill:#f3e5f5,stroke:#7b1fa2,stroke-width:3px,color:#000
     classDef outputStyle fill:#e8f5e9,stroke:#2e7d32,stroke-width:3px,color:#000
 
-    class Kotlin,Java,Functions,KSerializer sourceStyle
-    class KSP,Reflect,Serialization introspectorStyle
+    class Kotlin,Java,JavaApt,Functions,KSerializer sourceStyle
+    class KSP,Apt,Reflect,Serialization introspectorStyle
     class TypeGraph irStyle
     class JsonTransform,FuncTransform transformStyle
-    class KtClass,KtFunc,JsonSchema,FuncSchema,JsonObj,JsonStr outputStyle
+    class KtClass,KtFunc,JsonSchema,FuncSchema,JsonObj,JsonStr,AptResource outputStyle
 ```
 
 **The Transformation Story:**
 
-1. **Sources** — Kotlin classes, Java classes, Kotlin functions, or [SerialDescriptor][kser-descriptor] serve as input
-2. **Introspectors** — Extract type information at compile-time (KSP) or runtime (Reflection, Serialization)
+1. **Sources** — Kotlin classes, Java classes/records, Kotlin functions, or [SerialDescriptor][kser-descriptor] serve as input
+2. **Introspectors** — Extract type information at compile-time (KSP, [Java APT](apt.md)) or runtime (Reflection, Serialization)
 3. **TypeGraph** — Unified internal representation containing all type metadata
 4. **Transformers** — Convert TypeGraph to JSON Schema or Function Calling format
-5. **Outputs** — Generated Kotlin code, JsonSchema, FunctionCallingSchema, and then to JsonObject, or JSON strings
+5. **Outputs** — Generated Kotlin code, a generated `.json` resource (Java APT), JsonSchema, FunctionCallingSchema, and then to JsonObject, or JSON strings
 
 ## Module Dependencies
 
@@ -105,6 +111,7 @@ C4Context
         System(kxsGenJson, "kt-schema-generator-json")
         System(kxsJsn, "kt-schema-json")
         System(kxsKsp, "kt-schema-ksp")
+        System(kxsApt, "kt-schema-apt")
         System(kxsGradle, "kt-schema-gradle-plugin")
     }
 
@@ -112,6 +119,7 @@ C4Context
     Rel(kxsGenJson, kxsJsn, "uses")
     Rel(kxsGenCore, kxsAnnotations, "knows")
     Rel(kxsKsp, kxsGenJson, "uses")
+    Rel(kxsApt, kxsGenJson, "uses")
     Rel(kxsGradle, kxsKsp, "uses")
 
     Boundary(userCode, "User's Application Code") {
@@ -122,6 +130,7 @@ C4Context
 
     Rel(userModels, kxsAnnotations, "uses")
     Rel(kxsKsp, userModelsExt, "generates")
+    Rel(kxsApt, userModels, "generates schema resource for")
 
 ```
 
@@ -135,7 +144,10 @@ Top-level modules you might interact with:
 - **kt-schema-ksp-processor** — KSP processor that scans your code and generates the extension properties:
     - `KClass<T>.jsonSchema: JsonObject`
     - `KClass<T>.jsonSchemaString: String`
+- **kt-schema-apt** — [JSR 269 annotation processor](apt.md) for plain Java projects; generates a JSON Schema
+  resource per processed type instead of Kotlin extensions
 - **ksp-integration-tests** — KSP end‑to‑end tests for generation without the Gradle plugin
+- **apt-integration-tests** — Java-only end‑to‑end tests for `kt-schema-apt`
 
 ### Workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ graph LR
         Kotlin["Kotlin Classes<br/>@Schema annotated"]
         KSerializer["SerialDescriptor"]
         Java["Java Classes<br/>Third-party libs"]
-        JavaApt["Java Records<br/>@Schema or rootPackage"]
+        JavaApt["Java Records/Classes/Interfaces<br/>@Schema or rootPackage"]
         Functions["Kotlin Functions"]
     end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,10 +73,10 @@ graph LR
     JsonTransform --> JsonSchema
     FuncTransform --> FuncSchema
     JsonSchema --> JsonObj
+    JsonSchema --> AptResource
     FuncSchema --> KtFunc
     JsonObj --> JsonStr
     JsonObj --> KtClass
-    JsonObj --> AptResource
 
     classDef sourceStyle fill:#e3f2fd,stroke:#1565c0,stroke-width:3px,color:#000
     classDef introspectorStyle fill:#fff3e0,stroke:#ef6c00,stroke-width:3px,color:#000

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ ksp.useKSP2=true
 detekt.use.worker.api = true
 
 group=me.kpavlov.kt.schema
-version=0.7.0
+version=0.8.0-SNAPSHOT
 
 versionSuffix=SNAPSHOT
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.13.2"
+assertj = "3.27.6"
 detekt = "2.0.0-alpha.2"
 dokka = "2.2.0"
 jackson = "2.18.5" # pin it
@@ -19,11 +20,17 @@ slf4j = "2.0.18"
 vanniktechMavenPublish = "0.37.0"
 
 [libraries]
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging", version.ref = "logging" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 gradle-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktechMavenPublish" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version.ref = "junit-pioneer" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 koog-agents-tools = { module = "ai.koog:agents-tools", version.ref = "koog" }

--- a/kt-schema-apt/Module.md
+++ b/kt-schema-apt/Module.md
@@ -1,0 +1,53 @@
+# Module kt-schema-apt
+
+Compile-time JSON Schema generation for plain Java projects via a JSR 269 (`javax.annotation.processing`)
+annotation processor.
+
+Analyzes `@Schema`-annotated Java types — or every type under a configured root package — at compile time,
+writing one JSON Schema resource per type. No Kotlin required in consuming code.
+
+**Platform Support:** JVM only • Build-time only • Java 17+
+
+## Generated Output
+
+```java
+@Schema
+public record User(String name) {}
+
+// Generated resource:
+// META-INF/kt-schema/schemas/com/example/User.json
+```
+
+Unlike `kt-schema-ksp`, this module has no Kotlin code to attach extension properties to, so it writes the
+serialized `JsonSchema` directly as a classpath resource instead of generating Kotlin source.
+
+## Configuration
+
+Processor options, set via javac `-A` compiler arguments:
+
+- `me.kpavlov.kt.schema.rootPackage` — process every top-level type under this package (and sub-packages),
+  in addition to `@Schema`-annotated types
+
+See [Java Annotation Processor Guide](https://github.com/kpavlov/kt-schema/blob/main/docs/apt.md).
+
+## Features
+
+- Reuses the same [`TypeGraphToJsonSchemaTransformer`][me.kpavlov.kt.schema.generator.json.TypeGraphToJsonSchemaTransformer]
+  as `kt-schema-ksp`, so output ($id/$defs/$ref/nullability) is identical
+- Recognizes description/ignore/name-override annotations from Jackson, LangChain4j, Koog, etc. via the shared
+  [`Introspections`][me.kpavlov.kt.schema.generator.core.ir.Introspections] config, same as KSP and reflection
+
+## Limitations
+
+- Only Java `record`s are supported as root/nested types; enums, sealed hierarchies, generics,
+  collections/maps, and ordinary classes aren't yet
+- Reference-typed record components are always non-nullable/required — no `@Nullable` support yet
+- No `include`/`exclude`/`withSchemaObject`/`visibility`/`enabled` options (available in `kt-schema-ksp`)
+
+# Package me.kpavlov.kt.schema.apt
+
+JSR 269 annotation processor implementation.
+
+# Package me.kpavlov.kt.schema.apt.ir
+
+Intermediate representation introspection for `javax.lang.model` (Java APT) types.

--- a/kt-schema-apt/api/kt-schema-apt.api
+++ b/kt-schema-apt/api/kt-schema-apt.api
@@ -2,6 +2,7 @@ public final class me/kpavlov/kt/schema/apt/JsonSchemaProcessor : javax/annotati
 	public static final field Companion Lme/kpavlov/kt/schema/apt/JsonSchemaProcessor$Companion;
 	public static final field ROOT_PACKAGE_OPTION Ljava/lang/String;
 	public fun <init> ()V
+	public fun getSupportedSourceVersion ()Ljavax/lang/model/SourceVersion;
 	public fun process (Ljava/util/Set;Ljavax/annotation/processing/RoundEnvironment;)Z
 }
 

--- a/kt-schema-apt/api/kt-schema-apt.api
+++ b/kt-schema-apt/api/kt-schema-apt.api
@@ -1,0 +1,10 @@
+public final class me/kpavlov/kt/schema/apt/JsonSchemaProcessor : javax/annotation/processing/AbstractProcessor {
+	public static final field Companion Lme/kpavlov/kt/schema/apt/JsonSchemaProcessor$Companion;
+	public static final field ROOT_PACKAGE_OPTION Ljava/lang/String;
+	public fun <init> ()V
+	public fun process (Ljava/util/Set;Ljavax/annotation/processing/RoundEnvironment;)Z
+}
+
+public final class me/kpavlov/kt/schema/apt/JsonSchemaProcessor$Companion {
+}
+

--- a/kt-schema-apt/build.gradle.kts
+++ b/kt-schema-apt/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    `dokka-convention`
+    `kotlin-jvm-convention`
+    `publishing-convention`
+}
+
+dokka {
+    dokkaSourceSets.configureEach {
+    }
+}
+
+kotlin {
+    compilerOptions {
+        optIn.set(
+            listOf(
+                "me.kpavlov.kt.schema.generator.core.InternalSchemaGeneratorApi",
+            ),
+        )
+    }
+
+    dependencies {
+        implementation(project(":kt-schema-annotations"))
+        implementation(project(":kt-schema-generator-json"))
+
+        testImplementation(libs.junit.jupiter.params)
+        testImplementation(libs.kotest.assertions.core)
+        testImplementation(libs.kotest.assertions.json)
+        testImplementation(libs.kotlin.test)
+    }
+}

--- a/kt-schema-apt/gradle.properties
+++ b/kt-schema-apt/gradle.properties
@@ -1,0 +1,1 @@
+description=JSON-Schema Generator

--- a/kt-schema-apt/gradle.properties
+++ b/kt-schema-apt/gradle.properties
@@ -1,1 +1,1 @@
-description=JSON-Schema Generator
+description=Java Annotation Processor for JSON Schema Generation

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors
+package me.kpavlov.kt.schema.apt
+
+import kotlinx.serialization.json.Json
+import me.kpavlov.kt.schema.Schema
+import me.kpavlov.kt.schema.apt.ir.AptClassIntrospector
+import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
+import me.kpavlov.kt.schema.generator.json.TypeGraphToJsonSchemaTransformer
+import me.kpavlov.kt.schema.json.JsonSchema
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.RoundEnvironment
+import javax.annotation.processing.SupportedAnnotationTypes
+import javax.annotation.processing.SupportedOptions
+import javax.annotation.processing.SupportedSourceVersion
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+import javax.tools.StandardLocation
+
+/**
+ * JSR 269 annotation processor generating JSON Schema resources for `@Schema`-annotated
+ * Java types, reusing the shared schema IR and JSON Schema transformer from
+ * `kt-schema-generator-core`/`kt-schema-generator-json` — the same pipeline the KSP
+ * processor uses, so output shape ($id/$defs/$ref/nullability) stays identical.
+ *
+ * Supports `"*"` annotation types so javac invokes it in every round: this lets the
+ * [ROOT_PACKAGE_OPTION] scanning pick up types even when no `@Schema` annotation is
+ * present in the compilation. The processor never claims annotations (always returns
+ * `false`) and deduplicates by type name, so it coexists safely with other processors.
+ *
+ * @author Konstantin Pavlov
+ */
+@SupportedAnnotationTypes("*")
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedOptions(
+    JsonSchemaProcessor.ROOT_PACKAGE_OPTION,
+)
+public class JsonSchemaProcessor : AbstractProcessor() {
+    private val processedTypes = mutableSetOf<String>()
+    private val transformer =
+        TypeGraphToJsonSchemaTransformer(
+            // build JsonSchemaConfig upon Strict config, matching kt-schema-ksp's ClassSchemaStrategy
+            config =
+                with(JsonSchemaConfig.Strict) {
+                    JsonSchemaConfig(
+                        respectDefaultPresence = false,
+                        requireNullableFields = requireNullableFields,
+                        useUnionTypes = useUnionTypes,
+                        useNullableField = useNullableField,
+                        includePolymorphicDiscriminator = includePolymorphicDiscriminator,
+                        includeOpenAPIPolymorphicDiscriminator = includeOpenAPIPolymorphicDiscriminator,
+                    )
+                },
+        )
+
+    private val json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+        }
+
+    override fun process(
+        annotations: MutableSet<out TypeElement>,
+        roundEnv: RoundEnvironment,
+    ): Boolean {
+        if (roundEnv.processingOver()) return false
+
+        candidateTypes(roundEnv)
+            .filter { processedTypes.add(it.qualifiedName.toString()) }
+            .forEach(::processType)
+
+        return false
+    }
+
+    /**
+     * Types annotated with `@Schema`, plus — when [ROOT_PACKAGE_OPTION] is configured —
+     * every type declared under that package, so consumers don't have to annotate every
+     * class individually.
+     */
+    private fun candidateTypes(roundEnv: RoundEnvironment): Set<TypeElement> {
+        val annotated = roundEnv.getElementsAnnotatedWith(Schema::class.java).filterIsInstance<TypeElement>()
+
+        val rootPackage = processingEnv.options[ROOT_PACKAGE_OPTION]
+        val underRootPackage =
+            if (rootPackage.isNullOrBlank()) {
+                emptyList()
+            } else {
+                roundEnv.rootElements
+                    .filterIsInstance<TypeElement>()
+                    .filter { it.isUnderPackage(rootPackage) }
+            }
+
+        return (annotated + underRootPackage).toSet()
+    }
+
+    private fun TypeElement.isUnderPackage(rootPackage: String): Boolean {
+        val packageName = processingEnv.elementUtils.getPackageOf(this).qualifiedName.toString()
+        return packageName == rootPackage || packageName.startsWith("$rootPackage.")
+    }
+
+    private fun processType(type: TypeElement) {
+        val introspector = AptClassIntrospector(processingEnv.typeUtils)
+        val graph = introspector.introspect(type)
+        val schema = transformer.transform(graph, type.qualifiedName.toString())
+        writeSchemaResource(type, json.encodeToString(JsonSchema.serializer(), schema))
+    }
+
+    private fun writeSchemaResource(
+        source: TypeElement,
+        jsonString: String,
+    ) {
+        val relativePath = source.qualifiedName.toString().replace('.', '/') + ".json"
+        val path = "META-INF/kt-schema/schemas/$relativePath"
+        val file =
+            processingEnv.filer.createResource(
+                StandardLocation.CLASS_OUTPUT,
+                "",
+                path,
+                source,
+            )
+        file.openWriter().use { it.write(jsonString) }
+    }
+
+    public companion object {
+        /**
+         * Processor option (`-A<name>=<value>`) that, when set, processes every top-level type
+         * declared under the given package (and its sub-packages) in addition to types
+         * annotated with `@Schema`. Lets consumers skip annotating every class individually.
+         */
+        public const val ROOT_PACKAGE_OPTION: String = "me.kpavlov.kt.schema.rootPackage"
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -7,13 +7,16 @@ import me.kpavlov.kt.schema.apt.ir.AptClassIntrospector
 import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.TypeGraphToJsonSchemaTransformer
 import me.kpavlov.kt.schema.json.JsonSchema
+import java.io.IOException
 import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.FilerException
 import javax.annotation.processing.RoundEnvironment
 import javax.annotation.processing.SupportedAnnotationTypes
 import javax.annotation.processing.SupportedOptions
-import javax.annotation.processing.SupportedSourceVersion
 import javax.lang.model.SourceVersion
+import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
+import javax.tools.Diagnostic
 import javax.tools.StandardLocation
 
 /**
@@ -30,12 +33,14 @@ import javax.tools.StandardLocation
  * @author Konstantin Pavlov
  */
 @SupportedAnnotationTypes("*")
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions(
     JsonSchemaProcessor.ROOT_PACKAGE_OPTION,
 )
 public class JsonSchemaProcessor : AbstractProcessor() {
     private val processedTypes = mutableSetOf<String>()
+
+    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
+
     private val transformer =
         TypeGraphToJsonSchemaTransformer(
             // build JsonSchemaConfig upon Strict config, matching kt-schema-ksp's ClassSchemaStrategy
@@ -73,8 +78,8 @@ public class JsonSchemaProcessor : AbstractProcessor() {
 
     /**
      * Types annotated with `@Schema`, plus — when [ROOT_PACKAGE_OPTION] is configured —
-     * every type declared under that package, so consumers don't have to annotate every
-     * class individually.
+     * every record or class declared under that package, so consumers don't have to
+     * annotate every type individually.
      */
     private fun candidateTypes(roundEnv: RoundEnvironment): Set<TypeElement> {
         val annotated = roundEnv.getElementsAnnotatedWith(Schema::class.java).filterIsInstance<TypeElement>()
@@ -86,6 +91,7 @@ public class JsonSchemaProcessor : AbstractProcessor() {
             } else {
                 roundEnv.rootElements
                     .filterIsInstance<TypeElement>()
+                    .filter { it.kind == ElementKind.RECORD || it.kind == ElementKind.CLASS }
                     .filter { it.isUnderPackage(rootPackage) }
             }
 
@@ -98,10 +104,15 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     }
 
     private fun processType(type: TypeElement) {
-        val introspector = AptClassIntrospector(processingEnv.typeUtils)
-        val graph = introspector.introspect(type)
-        val schema = transformer.transform(graph, type.qualifiedName.toString())
-        writeSchemaResource(type, json.encodeToString(JsonSchema.serializer(), schema))
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            val introspector = AptClassIntrospector(processingEnv.typeUtils)
+            val graph = introspector.introspect(type)
+            val schema = transformer.transform(graph, type.qualifiedName.toString())
+            writeSchemaResource(type, json.encodeToString(JsonSchema.serializer(), schema))
+        } catch (e: Exception) {
+            reportError(type, "Failed to generate JSON Schema: ${e.message}")
+        }
     }
 
     private fun writeSchemaResource(
@@ -110,21 +121,35 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     ) {
         val relativePath = source.qualifiedName.toString().replace('.', '/') + ".json"
         val path = "META-INF/kt-schema/schemas/$relativePath"
-        val file =
-            processingEnv.filer.createResource(
-                StandardLocation.CLASS_OUTPUT,
-                "",
-                path,
-                source,
-            )
-        file.openWriter().use { it.write(jsonString) }
+        try {
+            val file =
+                processingEnv.filer.createResource(
+                    StandardLocation.CLASS_OUTPUT,
+                    "",
+                    path,
+                    source,
+                )
+            file.openWriter().use { it.write(jsonString) }
+        } catch (e: IOException) {
+            reportError(source, "Failed to write JSON Schema resource $path: ${e.message}")
+        } catch (e: FilerException) {
+            reportError(source, "Failed to create JSON Schema resource $path: ${e.message}")
+        }
+    }
+
+    private fun reportError(
+        type: TypeElement,
+        message: String,
+    ) {
+        processingEnv.messager.printMessage(Diagnostic.Kind.ERROR, message, type)
     }
 
     public companion object {
         /**
-         * Processor option (`-A<name>=<value>`) that, when set, processes every top-level type
-         * declared under the given package (and its sub-packages) in addition to types
-         * annotated with `@Schema`. Lets consumers skip annotating every class individually.
+         * Processor option (`-A<name>=<value>`) that, when set, processes every top-level
+         * record or class declared under the given package (and its sub-packages) in addition
+         * to types annotated with `@Schema`. Lets consumers skip annotating every type
+         * individually.
          */
         public const val ROOT_PACKAGE_OPTION: String = "me.kpavlov.kt.schema.rootPackage"
     }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -78,8 +78,8 @@ public class JsonSchemaProcessor : AbstractProcessor() {
 
     /**
      * Types annotated with `@Schema`, plus — when [ROOT_PACKAGE_OPTION] is configured —
-     * every record or class declared under that package, so consumers don't have to
-     * annotate every type individually.
+     * every record, class or interface declared under that package, so consumers don't
+     * have to annotate every type individually.
      */
     private fun candidateTypes(roundEnv: RoundEnvironment): Set<TypeElement> {
         val annotated = roundEnv.getElementsAnnotatedWith(Schema::class.java).filterIsInstance<TypeElement>()
@@ -91,12 +91,15 @@ public class JsonSchemaProcessor : AbstractProcessor() {
             } else {
                 roundEnv.rootElements
                     .filterIsInstance<TypeElement>()
-                    .filter { it.kind == ElementKind.RECORD || it.kind == ElementKind.CLASS }
+                    .filter { it.isSupported() }
                     .filter { it.isUnderPackage(rootPackage) }
             }
 
         return (annotated + underRootPackage).toSet()
     }
+
+    private fun TypeElement.isSupported(): Boolean =
+        kind == ElementKind.RECORD || kind == ElementKind.CLASS || kind == ElementKind.INTERFACE
 
     private fun TypeElement.isUnderPackage(rootPackage: String): Boolean {
         val packageName = processingEnv.elementUtils.getPackageOf(this).qualifiedName.toString()
@@ -147,9 +150,9 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     public companion object {
         /**
          * Processor option (`-A<name>=<value>`) that, when set, processes every top-level
-         * record or class declared under the given package (and its sub-packages) in addition
-         * to types annotated with `@Schema`. Lets consumers skip annotating every type
-         * individually.
+         * record, class or interface declared under the given package (and its sub-packages)
+         * in addition to types annotated with `@Schema`. Lets consumers skip annotating
+         * every type individually.
          */
         public const val ROOT_PACKAGE_OPTION: String = "me.kpavlov.kt.schema.rootPackage"
     }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -37,6 +37,8 @@ import javax.tools.StandardLocation
     JsonSchemaProcessor.ROOT_PACKAGE_OPTION,
 )
 public class JsonSchemaProcessor : AbstractProcessor() {
+    //region Processor state
+
     private val processedTypes = mutableSetOf<String>()
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
@@ -62,6 +64,10 @@ public class JsonSchemaProcessor : AbstractProcessor() {
             prettyPrint = true
             encodeDefaults = false
         }
+
+    //endregion
+
+    //region Processing
 
     override fun process(
         annotations: MutableSet<out TypeElement>,
@@ -106,6 +112,10 @@ public class JsonSchemaProcessor : AbstractProcessor() {
         return packageName == rootPackage || packageName.startsWith("$rootPackage.")
     }
 
+    //endregion
+
+    //region Resource writing
+
     private fun processType(type: TypeElement) {
         @Suppress("TooGenericExceptionCaught")
         try {
@@ -133,10 +143,10 @@ public class JsonSchemaProcessor : AbstractProcessor() {
                     source,
                 )
             file.openWriter().use { it.write(jsonString) }
-        } catch (e: IOException) {
-            reportError(source, "Failed to write JSON Schema resource $path: ${e.message}")
         } catch (e: FilerException) {
             reportError(source, "Failed to create JSON Schema resource $path: ${e.message}")
+        } catch (e: IOException) {
+            reportError(source, "Failed to write JSON Schema resource $path: ${e.message}")
         }
     }
 
@@ -147,6 +157,10 @@ public class JsonSchemaProcessor : AbstractProcessor() {
         processingEnv.messager.printMessage(Diagnostic.Kind.ERROR, message, type)
     }
 
+    //endregion
+
+    //region Public constants
+
     public companion object {
         /**
          * Processor option (`-A<name>=<value>`) that, when set, processes every top-level
@@ -156,4 +170,6 @@ public class JsonSchemaProcessor : AbstractProcessor() {
          */
         public const val ROOT_PACKAGE_OPTION: String = "me.kpavlov.kt.schema.rootPackage"
     }
+
+    //endregion
 }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -16,12 +16,20 @@ import javax.lang.model.util.Types
 internal class AptClassIntrospector(
     types: Types,
 ) : SchemaIntrospector<TypeElement, Unit> {
+    //region Configuration
+
     override val config = Unit
 
     private val context = AptIntrospectionContext(types)
+
+    //endregion
+
+    //region Introspection
 
     override fun introspect(root: TypeElement): TypeGraph {
         val rootRef = context.toRef(root.asType())
         return TypeGraph(root = rootRef, nodes = context.nodes)
     }
+
+    //endregion
 }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -7,9 +7,9 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Types
 
 /**
- * Java-APT-backed schema IR introspector. Supports records with primitive/String/boxed
- * component types and nested record references; generics/enums/sealed hierarchies are
- * not yet supported.
+ * Java-APT-backed schema IR introspector. Supports records and plain classes with
+ * primitive/String/boxed field types and nested references; generics/enums/sealed
+ * hierarchies are not yet supported.
  *
  * @author Konstantin Pavlov
  */

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors
+package me.kpavlov.kt.schema.apt.ir
+
+import me.kpavlov.kt.schema.generator.core.ir.SchemaIntrospector
+import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
+import javax.lang.model.element.TypeElement
+import javax.lang.model.util.Types
+
+/**
+ * Java-APT-backed schema IR introspector. Supports records with primitive/String/boxed
+ * component types and nested record references; generics/enums/sealed hierarchies are
+ * not yet supported.
+ *
+ * @author Konstantin Pavlov
+ */
+internal class AptClassIntrospector(
+    types: Types,
+) : SchemaIntrospector<TypeElement, Unit> {
+    override val config = Unit
+
+    private val context = AptIntrospectionContext(types)
+
+    override fun introspect(root: TypeElement): TypeGraph {
+        val rootRef = context.toRef(root.asType())
+        return TypeGraph(root = rootRef, nodes = context.nodes)
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -7,8 +7,8 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Types
 
 /**
- * Java-APT-backed schema IR introspector. Supports records and plain classes with
- * primitive/String/boxed field types and nested references; generics/enums/sealed
+ * Java-APT-backed schema IR introspector. Supports records, plain classes and interfaces
+ * with primitive/String/boxed field types and nested references; generics/enums/sealed
  * hierarchies are not yet supported.
  *
  * @author Konstantin Pavlov

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -14,6 +14,7 @@ import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
+import javax.lang.model.element.RecordComponentElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeKind
@@ -30,9 +31,12 @@ import javax.lang.model.util.Types
  * @author Konstantin Pavlov
  */
 @OptIn(InternalSchemaGeneratorApi::class)
+@Suppress("TooManyFunctions")
 internal class AptIntrospectionContext(
     private val types: Types,
 ) : BaseIntrospectionContext<TypeMirror>() {
+    //region Type conversion
+
     override fun toRef(type: TypeMirror): TypeRef {
         primitiveKindFor(type)?.let { return TypeRef.Inline(PrimitiveNode(it)) }
 
@@ -84,15 +88,10 @@ internal class AptIntrospectionContext(
             element.recordComponents.forEach { component ->
                 val name = component.simpleName.toString()
                 required += name
-                props += toProperty(name, component.asType(), fieldFor(element, name) ?: component)
+                props += toProperty(name, component.asType(), recordComponentDescription(component, element))
             }
 
-            ObjectNode(
-                name = element.qualifiedName.toString(),
-                properties = props,
-                required = required,
-                description = extractDescription(element),
-            )
+            objectNode(element, props, required)
         }
 
         return TypeRef.Ref(id)
@@ -114,15 +113,10 @@ internal class AptIntrospectionContext(
                 .forEach { field ->
                     val name = field.simpleName.toString()
                     required += name
-                    props += toProperty(name, field.asType(), field)
+                    props += toProperty(name, field.asType(), extractDescription(field))
                 }
 
-            ObjectNode(
-                name = element.qualifiedName.toString(),
-                properties = props,
-                required = required,
-                description = extractDescription(element),
-            )
+            objectNode(element, props, required)
         }
 
         return TypeRef.Ref(id)
@@ -146,15 +140,10 @@ internal class AptIntrospectionContext(
                 .forEach { method ->
                     val name = propertyName(method.simpleName.toString())
                     required += name
-                    props += toProperty(name, method.returnType, method)
+                    props += toProperty(name, method.returnType, extractDescription(method))
                 }
 
-            ObjectNode(
-                name = element.qualifiedName.toString(),
-                properties = props,
-                required = required,
-                description = extractDescription(element),
-            )
+            objectNode(element, props, required)
         }
 
         return TypeRef.Ref(id)
@@ -169,14 +158,26 @@ internal class AptIntrospectionContext(
             methodName.length > GET_PREFIX.length &&
                 methodName.startsWith(GET_PREFIX) &&
                 methodName[GET_PREFIX.length].isUpperCase() ->
-                methodName.substring(GET_PREFIX.length).replaceFirstChar { it.lowercase() }
+                decapitalize(methodName.substring(GET_PREFIX.length))
 
             methodName.length > IS_PREFIX.length &&
                 methodName.startsWith(IS_PREFIX) &&
                 methodName[IS_PREFIX.length].isUpperCase() ->
-                methodName.substring(IS_PREFIX.length).replaceFirstChar { it.lowercase() }
+                decapitalize(methodName.substring(IS_PREFIX.length))
 
             else -> methodName
+        }
+
+    /**
+     * Applies JavaBeans decapitalization to a property suffix: `Name` → `name`, while
+     * preserving all-uppercase acronyms such as `URL` or `OK` and leaving mixed-case
+     * suffixes such as `urlPath` untouched.
+     */
+    private fun decapitalize(name: String): String =
+        if (name.length > 1 && name[0].isUpperCase() && name[1].isUpperCase()) {
+            name
+        } else {
+            name.replaceFirstChar { it.lowercase() }
         }
 
     private companion object {
@@ -184,21 +185,53 @@ internal class AptIntrospectionContext(
         const val IS_PREFIX: String = "is"
     }
 
+    //endregion
+
+    //region Property conversion
+
     private fun toProperty(
         name: String,
         type: TypeMirror,
-        element: Element,
+        description: String?,
     ): Property =
         Property(
             name = name,
             type = toRef(type),
+            description = description,
+        )
+
+    private fun objectNode(
+        element: TypeElement,
+        properties: List<Property>,
+        required: Set<String>,
+    ): ObjectNode =
+        ObjectNode(
+            name = element.qualifiedName.toString(),
+            properties = properties,
+            required = required,
             description = extractDescription(element),
         )
 
+    //endregion
+
+    //region Annotation helpers
+
+    /**
+     * Resolves a record component's description from its annotation targets, in order of
+     * precedence: the record component itself, its accessor, then the backing field.
+     */
+    private fun recordComponentDescription(
+        component: RecordComponentElement,
+        type: TypeElement,
+    ): String? =
+        extractDescription(component)
+            ?: extractDescription(component.accessor)
+            ?: fieldFor(type, component.simpleName.toString())?.let(::extractDescription)
+
     /**
      * Record component annotations propagate to the backing field (among other targets),
-     * so the field is the most reliable place to read them back from regardless of which
-     * Java targets the annotation declares `@Target` for.
+     * so the field is used as a last-resort description target for annotations whose
+     * `@Target` does not cover the record component or its accessor.
      */
     private fun fieldFor(
         type: TypeElement,
@@ -221,4 +254,6 @@ internal class AptIntrospectionContext(
                 annotationArguments = args,
             )
         }
+
+    //endregion
 }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -12,6 +12,7 @@ import me.kpavlov.kt.schema.generator.core.ir.TypeId
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
@@ -22,8 +23,8 @@ import javax.lang.model.util.Types
 /**
  * Introspection context for the Java annotation-processor (JSR 269) front end.
  *
- * Supports Java records and plain classes with primitive/boxed/String fields and nested
- * record/class references. Reference types are treated as non-nullable/required: Java has
+ * Supports Java records, plain classes and interfaces with primitive/boxed/String fields
+ * and nested references. Reference types are treated as non-nullable/required: Java has
  * no notion of optionality/default values, so every property is required.
  *
  * @author Konstantin Pavlov
@@ -37,9 +38,10 @@ internal class AptIntrospectionContext(
 
         return handleRecord(type)
             ?: handleClass(type)
+            ?: handleInterface(type)
             ?: error(
                 "Unsupported type for kt-schema-apt " +
-                    "(only records, classes, primitives and String are supported): $type",
+                    "(only records, classes, interfaces, primitives and String are supported): $type",
             )
     }
 
@@ -124,6 +126,62 @@ internal class AptIntrospectionContext(
         }
 
         return TypeRef.Ref(id)
+    }
+
+    private fun handleInterface(type: TypeMirror): TypeRef? {
+        val element = asTypeElement(type)
+        if (element == null || element.kind != ElementKind.INTERFACE) return null
+
+        val id = TypeId(element.qualifiedName.toString())
+
+        withCycleDetection(type, id) {
+            val props = ArrayList<Property>()
+            val required = LinkedHashSet<String>()
+
+            element.enclosedElements
+                .filterIsInstance<ExecutableElement>()
+                .filter { it.kind == ElementKind.METHOD }
+                .filter { !it.modifiers.contains(Modifier.STATIC) }
+                .filter { it.parameters.isEmpty() && it.returnType.kind != TypeKind.VOID }
+                .forEach { method ->
+                    val name = propertyName(method.simpleName.toString())
+                    required += name
+                    props += toProperty(name, method.returnType, method)
+                }
+
+            ObjectNode(
+                name = element.qualifiedName.toString(),
+                properties = props,
+                required = required,
+                description = extractDescription(element),
+            )
+        }
+
+        return TypeRef.Ref(id)
+    }
+
+    /**
+     * Maps a no-arg accessor method to a property name using the JavaBeans convention:
+     * `getName()` → `name`, `isActive()` → `active`, and a bare `name()` accessor is kept as-is.
+     */
+    private fun propertyName(methodName: String): String =
+        when {
+            methodName.length > GET_PREFIX.length &&
+                methodName.startsWith(GET_PREFIX) &&
+                methodName[GET_PREFIX.length].isUpperCase() ->
+                methodName.substring(GET_PREFIX.length).replaceFirstChar { it.lowercase() }
+
+            methodName.length > IS_PREFIX.length &&
+                methodName.startsWith(IS_PREFIX) &&
+                methodName[IS_PREFIX.length].isUpperCase() ->
+                methodName.substring(IS_PREFIX.length).replaceFirstChar { it.lowercase() }
+
+            else -> methodName
+        }
+
+    private companion object {
+        const val GET_PREFIX: String = "get"
+        const val IS_PREFIX: String = "is"
     }
 
     private fun toProperty(

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Konstantin Pavlov and contributors
+package me.kpavlov.kt.schema.apt.ir
+
+import me.kpavlov.kt.schema.generator.core.InternalSchemaGeneratorApi
+import me.kpavlov.kt.schema.generator.core.ir.BaseIntrospectionContext
+import me.kpavlov.kt.schema.generator.core.ir.Introspections
+import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
+import me.kpavlov.kt.schema.generator.core.ir.Property
+import me.kpavlov.kt.schema.generator.core.ir.TypeId
+import me.kpavlov.kt.schema.generator.core.ir.TypeRef
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+import javax.lang.model.type.TypeKind
+import javax.lang.model.type.TypeMirror
+import javax.lang.model.util.Types
+
+/**
+ * Introspection context for the Java annotation-processor (JSR 269) front end.
+ *
+ * Supports Java records with primitive/boxed/String components and nested record
+ * references. Reference types are treated as non-nullable/required: Java records have
+ * no notion of optionality/default values, so every component is required.
+ *
+ * @author Konstantin Pavlov
+ */
+@OptIn(InternalSchemaGeneratorApi::class)
+internal class AptIntrospectionContext(
+    private val types: Types,
+) : BaseIntrospectionContext<TypeMirror>() {
+    override fun toRef(type: TypeMirror): TypeRef {
+        primitiveKindFor(type)?.let { return TypeRef.Inline(PrimitiveNode(it)) }
+
+        return requireNotNull(handleRecord(type)) {
+            "Unsupported type for kt-schema-apt (only records, primitives and String are supported): $type"
+        }
+    }
+
+    private fun primitiveKindFor(type: TypeMirror): PrimitiveKind? =
+        when (type.kind) {
+            TypeKind.BOOLEAN -> PrimitiveKind.BOOLEAN
+            TypeKind.INT, TypeKind.SHORT, TypeKind.BYTE -> PrimitiveKind.INT
+            TypeKind.LONG -> PrimitiveKind.LONG
+            TypeKind.FLOAT -> PrimitiveKind.FLOAT
+            TypeKind.DOUBLE -> PrimitiveKind.DOUBLE
+            TypeKind.DECLARED -> boxedPrimitiveKindFor(type)
+            else -> null
+        }
+
+    private fun boxedPrimitiveKindFor(type: TypeMirror): PrimitiveKind? =
+        when (asTypeElement(type)?.qualifiedName?.toString()) {
+            "java.lang.String" -> PrimitiveKind.STRING
+            "java.lang.Boolean" -> PrimitiveKind.BOOLEAN
+            "java.lang.Integer", "java.lang.Short", "java.lang.Byte" -> PrimitiveKind.INT
+            "java.lang.Long" -> PrimitiveKind.LONG
+            "java.lang.Float" -> PrimitiveKind.FLOAT
+            "java.lang.Double" -> PrimitiveKind.DOUBLE
+            else -> null
+        }
+
+    private fun asTypeElement(type: TypeMirror): TypeElement? = types.asElement(type) as? TypeElement
+
+    private fun handleRecord(type: TypeMirror): TypeRef? {
+        val element = asTypeElement(type)
+        if (element == null || element.kind != ElementKind.RECORD) return null
+
+        val id = TypeId(element.qualifiedName.toString())
+
+        withCycleDetection(type, id) {
+            val props = ArrayList<Property>()
+            val required = LinkedHashSet<String>()
+
+            element.recordComponents.forEach { component ->
+                val name = component.simpleName.toString()
+                required += name
+                props +=
+                    Property(
+                        name = name,
+                        type = toRef(component.asType()),
+                        description = extractDescription(fieldFor(element, name) ?: component),
+                    )
+            }
+
+            ObjectNode(
+                name = element.qualifiedName.toString(),
+                properties = props,
+                required = required,
+                description = extractDescription(element),
+            )
+        }
+
+        return TypeRef.Ref(id)
+    }
+
+    /**
+     * Record component annotations propagate to the backing field (among other targets),
+     * so the field is the most reliable place to read them back from regardless of which
+     * Java targets the annotation declares `@Target` for.
+     */
+    private fun fieldFor(
+        type: TypeElement,
+        name: String,
+    ): VariableElement? =
+        type.enclosedElements
+            .filterIsInstance<VariableElement>()
+            .firstOrNull { it.kind == ElementKind.FIELD && it.simpleName.contentEquals(name) }
+
+    private fun extractDescription(element: Element): String? =
+        element.annotationMirrors.firstNotNullOfOrNull { mirror ->
+            val annotationElement = mirror.annotationType.asElement() as TypeElement
+            val args =
+                mirror.elementValues.entries.map { (attribute, value) ->
+                    attribute.simpleName.toString() to value.value
+                }
+            Introspections.getDescriptionFromAnnotation(
+                simpleName = annotationElement.simpleName.toString(),
+                qualifiedName = annotationElement.qualifiedName.toString(),
+                annotationArguments = args,
+            )
+        }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -12,6 +12,7 @@ import me.kpavlov.kt.schema.generator.core.ir.TypeId
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
+import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeKind
@@ -21,9 +22,9 @@ import javax.lang.model.util.Types
 /**
  * Introspection context for the Java annotation-processor (JSR 269) front end.
  *
- * Supports Java records with primitive/boxed/String components and nested record
- * references. Reference types are treated as non-nullable/required: Java records have
- * no notion of optionality/default values, so every component is required.
+ * Supports Java records and plain classes with primitive/boxed/String fields and nested
+ * record/class references. Reference types are treated as non-nullable/required: Java has
+ * no notion of optionality/default values, so every property is required.
  *
  * @author Konstantin Pavlov
  */
@@ -34,9 +35,12 @@ internal class AptIntrospectionContext(
     override fun toRef(type: TypeMirror): TypeRef {
         primitiveKindFor(type)?.let { return TypeRef.Inline(PrimitiveNode(it)) }
 
-        return requireNotNull(handleRecord(type)) {
-            "Unsupported type for kt-schema-apt (only records, primitives and String are supported): $type"
-        }
+        return handleRecord(type)
+            ?: handleClass(type)
+            ?: error(
+                "Unsupported type for kt-schema-apt " +
+                    "(only records, classes, primitives and String are supported): $type",
+            )
     }
 
     private fun primitiveKindFor(type: TypeMirror): PrimitiveKind? =
@@ -46,6 +50,7 @@ internal class AptIntrospectionContext(
             TypeKind.LONG -> PrimitiveKind.LONG
             TypeKind.FLOAT -> PrimitiveKind.FLOAT
             TypeKind.DOUBLE -> PrimitiveKind.DOUBLE
+            TypeKind.CHAR -> PrimitiveKind.STRING
             TypeKind.DECLARED -> boxedPrimitiveKindFor(type)
             else -> null
         }
@@ -58,6 +63,7 @@ internal class AptIntrospectionContext(
             "java.lang.Long" -> PrimitiveKind.LONG
             "java.lang.Float" -> PrimitiveKind.FLOAT
             "java.lang.Double" -> PrimitiveKind.DOUBLE
+            "java.lang.Character" -> PrimitiveKind.STRING
             else -> null
         }
 
@@ -76,12 +82,7 @@ internal class AptIntrospectionContext(
             element.recordComponents.forEach { component ->
                 val name = component.simpleName.toString()
                 required += name
-                props +=
-                    Property(
-                        name = name,
-                        type = toRef(component.asType()),
-                        description = extractDescription(fieldFor(element, name) ?: component),
-                    )
+                props += toProperty(name, component.asType(), fieldFor(element, name) ?: component)
             }
 
             ObjectNode(
@@ -94,6 +95,47 @@ internal class AptIntrospectionContext(
 
         return TypeRef.Ref(id)
     }
+
+    private fun handleClass(type: TypeMirror): TypeRef? {
+        val element = asTypeElement(type)
+        if (element == null || element.kind != ElementKind.CLASS) return null
+
+        val id = TypeId(element.qualifiedName.toString())
+
+        withCycleDetection(type, id) {
+            val props = ArrayList<Property>()
+            val required = LinkedHashSet<String>()
+
+            element.enclosedElements
+                .filterIsInstance<VariableElement>()
+                .filter { it.kind == ElementKind.FIELD && !it.modifiers.contains(Modifier.STATIC) }
+                .forEach { field ->
+                    val name = field.simpleName.toString()
+                    required += name
+                    props += toProperty(name, field.asType(), field)
+                }
+
+            ObjectNode(
+                name = element.qualifiedName.toString(),
+                properties = props,
+                required = required,
+                description = extractDescription(element),
+            )
+        }
+
+        return TypeRef.Ref(id)
+    }
+
+    private fun toProperty(
+        name: String,
+        type: TypeMirror,
+        element: Element,
+    ): Property =
+        Property(
+            name = name,
+            type = toRef(type),
+            description = extractDescription(element),
+        )
 
     /**
      * Record component annotations propagate to the backing field (among other targets),

--- a/kt-schema-apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/kt-schema-apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+me.kpavlov.kt.schema.apt.JsonSchemaProcessor

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -256,13 +256,98 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
-    fun `should not generate schema for interface under root package`(
+    fun `should generate schema for annotated interface`(
         @TempDir tempDir: Path,
     ) {
         val source = """
             package com.example;
 
-            public interface Marker {}
+            import me.kpavlov.kt.schema.Description;
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public interface Person {
+                @Description("Name of the person")
+                String getName();
+
+                @Description("Age of the person")
+                int getAge();
+            }
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the person"
+                    },
+                    "age": {
+                        "type": "integer",
+                        "description": "Age of the person"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name", "age"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for interface via root package option`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public interface Product {
+                String name();
+                int price();
+            }
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Product.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.Product",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "price": { "type": "integer" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "price"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should not generate schema for enum under root package`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public enum Color {
+                RED, GREEN, BLUE
+            }
         """.trimIndent()
 
         val outputDir = compile(
@@ -390,7 +475,7 @@ class JsonSchemaProcessorTest {
         val sourceFiles = sources.map { code ->
             val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
             val cls =
-                Regex("""(?:public\s+)?(?:record|class|interface)\s+(\w+)""").find(code)?.groupValues?.get(1)
+                Regex("""(?:public\s+)?(?:record|class|interface|enum)\s+(\w+)""").find(code)?.groupValues?.get(1)
                     ?: error("Cannot infer class name from source:\n$code")
             val fqn = "$pkg.$cls"
             object : SimpleJavaFileObject(

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -4,6 +4,8 @@ import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import java.io.StringWriter
 import java.net.URI
 import java.nio.file.Path
@@ -14,6 +16,7 @@ import javax.tools.ToolProvider
 
 class JsonSchemaProcessorTest {
 
+    //region test cases
     @Test
     fun `should generate schema for annotated record`(
         @TempDir tempDir: Path,
@@ -210,6 +213,160 @@ class JsonSchemaProcessorTest {
         schemaFiles shouldBe emptyList()
     }
 
+    @Test
+    fun `should generate schema for plain class via root package option`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public class Company {
+                private final String name;
+                private final int founded;
+
+                public Company(String name, int founded) {
+                    this.name = name;
+                    this.founded = founded;
+                }
+            }
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Company.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.Company",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "founded": { "type": "integer" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "founded"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should not generate schema for interface under root package`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public interface Marker {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFiles =
+            outputDir.toFile().walkTopDown().filter { it.name.endsWith(".json") }.toList()
+        schemaFiles shouldBe emptyList()
+    }
+
+    @Test
+    fun `should generate schema for record in nested subpackage via root package option`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example.sub.sub;
+
+            public record DeepRecord(String value) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile =
+            outputDir.resolve("META-INF/kt-schema/schemas/com/example/sub/sub/DeepRecord.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.sub.sub.DeepRecord",
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "additionalProperties": false,
+                "required": ["value"]
+            }
+        """.trimIndent()
+    }
+
+    @ParameterizedTest(name = "should map {0} to JSON Schema type {1}")
+    @CsvSource(
+        "String, string",
+        "int, integer",
+        "boolean, boolean",
+        "byte, integer",
+        "short, integer",
+        "long, integer",
+        "float, number",
+        "double, number",
+        "char, string",
+        "Boolean, boolean",
+        "Byte, integer",
+        "Short, integer",
+        "Integer, integer",
+        "Long, integer",
+        "Float, number",
+        "Double, number",
+        "Character, string",
+    )
+    fun `should map scalar component types to JSON Schema types`(
+        javaType: String,
+        expectedJsonType: String,
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Scalars($javaType value) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Scalars.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.Scalars",
+                "type": "object",
+                "properties": {
+                    "value": { "type": "$expectedJsonType" }
+                },
+                "additionalProperties": false,
+                "required": ["value"]
+            }
+        """.trimIndent()
+    }
+
+    //endregion
+
+    //region compiler helpers
+
     private fun compile(
         source: String,
         tempDir: Path,
@@ -233,7 +390,7 @@ class JsonSchemaProcessorTest {
         val sourceFiles = sources.map { code ->
             val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
             val cls =
-                Regex("""(?:public\s+)?record\s+(\w+)""").find(code)?.groupValues?.get(1)
+                Regex("""(?:public\s+)?(?:record|class|interface)\s+(\w+)""").find(code)?.groupValues?.get(1)
                     ?: error("Cannot infer class name from source:\n$code")
             val fqn = "$pkg.$cls"
             object : SimpleJavaFileObject(
@@ -267,4 +424,5 @@ class JsonSchemaProcessorTest {
 
         return outputDir
     }
+    //endregion
 }

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -1,0 +1,270 @@
+package me.kpavlov.kt.schema.apt
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.StringWriter
+import java.net.URI
+import java.nio.file.Path
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+import javax.tools.ToolProvider
+
+class JsonSchemaProcessorTest {
+
+    @Test
+    fun `should generate schema for annotated record`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Person(String name, int age) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+                "${'$'}id": "com.example.Person",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "age"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record via root package option`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Foo(String value) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Foo",
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "additionalProperties": false,
+                "required": ["value"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for unannotated record via root package option`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public record Person(String name, int age) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Person",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "age"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schemas for nested record references`(
+        @TempDir tempDir: Path,
+    ) {
+        val addressSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Address(String city, String street) {}
+        """.trimIndent()
+
+        val personSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Person(String name, int age, Address address) {}
+        """.trimIndent()
+
+        val outputDir = compile(listOf(addressSource, personSource), tempDir)
+
+        val personSchema =
+            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json").toFile()
+        val addressSchema =
+            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Address.json").toFile()
+
+        personSchema.exists() shouldBe true
+        // language=json
+        personSchema.readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Person",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" },
+                    "address": {
+                        "$ref": "#/$defs/com.example.Address"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name", "age", "address"],
+                "$defs": {
+                    "com.example.Address": {
+                        "type": "object",
+                        "properties": {
+                            "city": { "type": "string" },
+                            "street": { "type": "string" }
+                        },
+                        "additionalProperties": false,
+                        "required": ["city", "street"]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        addressSchema.exists() shouldBe true
+        // language=json
+        addressSchema.readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Address",
+                "type": "object",
+                "properties": {
+                    "city": { "type": "string" },
+                    "street": { "type": "string" }
+                },
+                "additionalProperties": false,
+                "required": ["city", "street"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should not generate schema when no annotated types`(
+        @TempDir tempDir: Path,
+    ) {
+        val source = """
+            package com.example;
+
+            public record PlainRecord(String value) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFiles =
+            outputDir.toFile().walkTopDown().filter { it.name.endsWith(".json") }.toList()
+        schemaFiles shouldBe emptyList()
+    }
+
+    private fun compile(
+        source: String,
+        tempDir: Path,
+        options: List<String> = emptyList(),
+    ): Path {
+        return compile(listOf(source), tempDir, options)
+    }
+
+    private fun compile(
+        sources: List<String>,
+        tempDir: Path,
+        options: List<String> = emptyList(),
+    ): Path {
+        val compiler = ToolProvider.getSystemJavaCompiler()
+            ?: error("No system Java compiler available — run on JDK, not JRE")
+
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val outputDir = tempDir.resolve("classes")
+        outputDir.toFile().mkdirs()
+
+        val sourceFiles = sources.map { code ->
+            val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
+            val cls =
+                Regex("""(?:public\s+)?record\s+(\w+)""").find(code)?.groupValues?.get(1)
+                    ?: error("Cannot infer class name from source:\n$code")
+            val fqn = "$pkg.$cls"
+            object : SimpleJavaFileObject(
+                URI.create("string:///${fqn.replace('.', '/')}${JavaFileObject.Kind.SOURCE.extension}"),
+                JavaFileObject.Kind.SOURCE,
+            ) {
+                override fun getCharContent(ignoreEncodingErrors: Boolean) = code
+            }
+        }
+
+        val allOptions = mutableListOf("-d", outputDir.toFile().absolutePath)
+        allOptions.addAll(options)
+
+        val writer = StringWriter()
+        val task = compiler.getTask(
+            writer,
+            null,
+            diagnostics,
+            allOptions,
+            null,
+            sourceFiles,
+        )
+        task.setProcessors(listOf(JsonSchemaProcessor()))
+
+        val success = task.call()
+
+        if (!success) {
+            val messages = diagnostics.diagnostics.joinToString("\n") { it.toString() }
+            error("Compilation failed:\n$messages\nCompiler output:\n$writer")
+        }
+
+        return outputDir
+    }
+}

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -35,10 +35,10 @@ class JsonSchemaProcessorTest {
         val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.Person",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Person",
                 "type": "object",
                 "properties": {
                     "name": { "type": "string" },
@@ -51,9 +51,167 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
+    fun `should resolve record component description from record component annotation`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val annotationSource = """
+            package com.example;
+
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Target(ElementType.RECORD_COMPONENT)
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Description {
+                String value();
+            }
+        """.trimIndent()
+
+        // language=java
+        val recordSource = """
+            package com.example;
+
+            public record Foo(@Description("component description") String name) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            sources = listOf(annotationSource, recordSource),
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Foo",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "component description"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should resolve record component description from accessor annotation`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val annotationSource = """
+            package com.example;
+
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Target(ElementType.METHOD)
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Description {
+                String value();
+            }
+        """.trimIndent()
+
+        val recordSource = """
+            package com.example;
+
+            public record Foo(@Description("accessor description") String name) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            sources = listOf(annotationSource, recordSource),
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Foo",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "accessor description"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should resolve record component description from backing field annotation`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val annotationSource = """
+            package com.example;
+
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Target(ElementType.FIELD)
+            @Retention(RetentionPolicy.RUNTIME)
+            public @interface Description {
+                String value();
+            }
+        """.trimIndent()
+
+        val recordSource = """
+            package com.example;
+
+            public record Foo(@Description("field description") String name) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            sources = listOf(annotationSource, recordSource),
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Foo",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "field description"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["name"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
     fun `should generate schema for record via root package option`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -90,6 +248,7 @@ class JsonSchemaProcessorTest {
     fun `should generate schema for unannotated record via root package option`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -124,6 +283,7 @@ class JsonSchemaProcessorTest {
     fun `should generate schemas for nested record references`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val addressSource = """
             package com.example;
 
@@ -133,6 +293,7 @@ class JsonSchemaProcessorTest {
             public record Address(String city, String street) {}
         """.trimIndent()
 
+        // language=java
         val personSource = """
             package com.example;
 
@@ -200,6 +361,7 @@ class JsonSchemaProcessorTest {
     fun `should not generate schema when no annotated types`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -217,6 +379,7 @@ class JsonSchemaProcessorTest {
     fun `should generate schema for plain class via root package option`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -240,10 +403,10 @@ class JsonSchemaProcessorTest {
         val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Company.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.Company",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Company",
                 "type": "object",
                 "properties": {
                     "name": { "type": "string" },
@@ -259,6 +422,7 @@ class JsonSchemaProcessorTest {
     fun `should generate schema for annotated interface`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -280,10 +444,10 @@ class JsonSchemaProcessorTest {
         val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.Person",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Person",
                 "type": "object",
                 "properties": {
                     "name": {
@@ -302,9 +466,54 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
+    fun `should decapitalize bean accessors following JavaBeans convention`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            public interface Resource {
+                String getName();
+                String getURL();
+                String getOK();
+                String getUrlPath();
+                boolean isActive();
+            }
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+        )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Resource.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Resource",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "URL": { "type": "string" },
+                    "OK": { "type": "string" },
+                    "urlPath": { "type": "string" },
+                    "active": { "type": "boolean" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "URL", "OK", "urlPath", "active"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
     fun `should generate schema for interface via root package option`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -323,10 +532,10 @@ class JsonSchemaProcessorTest {
         val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Product.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.Product",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Product",
                 "type": "object",
                 "properties": {
                     "name": { "type": "string" },
@@ -342,6 +551,7 @@ class JsonSchemaProcessorTest {
     fun `should not generate schema for enum under root package`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -365,6 +575,7 @@ class JsonSchemaProcessorTest {
     fun `should generate schema for record in nested subpackage via root package option`(
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example.sub.sub;
 
@@ -381,10 +592,10 @@ class JsonSchemaProcessorTest {
             outputDir.resolve("META-INF/kt-schema/schemas/com/example/sub/sub/DeepRecord.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.sub.sub.DeepRecord",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.sub.sub.DeepRecord",
                 "type": "object",
                 "properties": {
                     "value": { "type": "string" }
@@ -420,6 +631,7 @@ class JsonSchemaProcessorTest {
         expectedJsonType: String,
         @TempDir tempDir: Path,
     ) {
+        // language=java
         val source = """
             package com.example;
 
@@ -434,13 +646,13 @@ class JsonSchemaProcessorTest {
         val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Scalars.json")
         schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson """
+        schemaFile.toFile().readText() shouldEqualJson $$"""
             {
-                "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
-                "${'$'}id": "com.example.Scalars",
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Scalars",
                 "type": "object",
                 "properties": {
-                    "value": { "type": "$expectedJsonType" }
+                    "value": { "type": "$$expectedJsonType" }
                 },
                 "additionalProperties": false,
                 "required": ["value"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,8 @@ include(
     ":kt-schema-generator-core",
     ":kt-schema-generator-json",
     ":kt-schema-ksp",
+    ":kt-schema-apt",
     ":ksp-integration-tests",
+    ":apt-integration-tests",
     ":docs",
 )


### PR DESCRIPTION
## Description

The PR adds the `kt-schema-apt` Java annotation processor. It discovers annotated types or types under `rootPackage`, introspects supported Java records, classes, and interfaces, and writes JSON Schema resources. New tests cover processor behavior and Java integration fixtures. Documentation, architecture diagrams, build configuration, dependency aliases, and the project version now include Java APT support.

Closes #74

### New Features

  * Added Java Annotation Processing support for compile-time JSON Schema generation.
  * Supports annotated Java records, classes, and interfaces, including nested types and package-based discovery.
  * Generated schemas are available as application resources for runtime loading.
  * Added configuration options for selecting the root package and generation behavior.

### Documentation

  * Added Java APT setup, configuration, supported types, limitations, and usage guidance.
  * Updated architecture and approach comparisons to include APT.

### Tests

  * Added integration coverage for records, classes, interfaces, nested types, and unsupported types.

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [x] **No debug code**: Removed commented-out code and debug statements

This PR was created with AI assistance
