### PR TITLE
perf: memoize type nodes across roots in apt processor

### DIFF
--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -43,6 +43,12 @@ public class JsonSchemaProcessor : AbstractProcessor() {
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 
+    /**
+     * Shared across roots so nested types referenced by several roots are introspected
+     * once; `processingEnv` is only available after `init()`, hence the lazy delegate.
+     */
+    private val introspector by lazy { AptClassIntrospector(processingEnv.typeUtils) }
+
     private val transformer =
         TypeGraphToJsonSchemaTransformer(
             // build JsonSchemaConfig upon Strict config, matching kt-schema-ksp's ClassSchemaStrategy
@@ -119,7 +125,6 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     private fun processType(type: TypeElement) {
         @Suppress("TooGenericExceptionCaught")
         try {
-            val introspector = AptClassIntrospector(processingEnv.typeUtils)
             val graph = introspector.introspect(type)
             val schema = transformer.transform(graph, type.qualifiedName.toString())
             writeSchemaResource(type, json.encodeToString(JsonSchema.serializer(), schema))

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -3,7 +3,10 @@ package me.kpavlov.kt.schema.apt.ir
 
 import me.kpavlov.kt.schema.generator.core.ir.SchemaIntrospector
 import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
+import me.kpavlov.kt.schema.generator.core.ir.TypeId
+import me.kpavlov.kt.schema.generator.core.ir.TypeNode
 import javax.lang.model.element.TypeElement
+import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Types
 
 /**
@@ -11,22 +14,27 @@ import javax.lang.model.util.Types
  * with primitive/String/boxed field types and nested references; generics/enums/sealed
  * hierarchies are not yet supported.
  *
+ * A fresh [AptIntrospectionContext] is created per root so `$defs` stay scoped to the
+ * types reachable from that root; [nodeCache] memoizes built nodes across roots so nested
+ * types shared between roots are introspected once.
+ *
  * @author Konstantin Pavlov
  */
 internal class AptClassIntrospector(
-    types: Types,
+    private val types: Types,
 ) : SchemaIntrospector<TypeElement, Unit> {
     //region Configuration
 
     override val config = Unit
 
-    private val context = AptIntrospectionContext(types)
+    private val nodeCache: MutableMap<TypeId, CachedNode> = mutableMapOf()
 
     //endregion
 
     //region Introspection
 
     override fun introspect(root: TypeElement): TypeGraph {
+        val context = AptIntrospectionContext(types, nodeCache)
         val rootRef = context.toRef(root.asType())
         return TypeGraph(root = rootRef, nodes = context.nodes)
     }

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -9,6 +9,7 @@ import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
 import me.kpavlov.kt.schema.generator.core.ir.Property
 import me.kpavlov.kt.schema.generator.core.ir.TypeId
+import me.kpavlov.kt.schema.generator.core.ir.TypeNode
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
@@ -28,12 +29,18 @@ import javax.lang.model.util.Types
  * and nested references. Reference types are treated as non-nullable/required: Java has
  * no notion of optionality/default values, so every property is required.
  *
+ * A fresh context is created per root type so `$defs` stay scoped to the types reachable
+ * from that root; [nodeCache] memoizes built nodes across roots so nested types shared
+ * between roots are introspected once. On a cache hit the node's `$ref` targets are
+ * re-registered into the current context to keep `$defs` complete.
+ *
  * @author Konstantin Pavlov
  */
 @OptIn(InternalSchemaGeneratorApi::class)
 @Suppress("TooManyFunctions")
 internal class AptIntrospectionContext(
     private val types: Types,
+    private val nodeCache: MutableMap<TypeId, CachedNode>,
 ) : BaseIntrospectionContext<TypeMirror>() {
     //region Type conversion
 
@@ -82,16 +89,18 @@ internal class AptIntrospectionContext(
         val id = TypeId(element.qualifiedName.toString())
 
         withCycleDetection(type, id) {
-            val props = ArrayList<Property>()
-            val required = LinkedHashSet<String>()
+            buildOrGet(type, id) {
+                val props = ArrayList<Property>()
+                val required = LinkedHashSet<String>()
 
-            element.recordComponents.forEach { component ->
-                val name = component.simpleName.toString()
-                required += name
-                props += toProperty(name, component.asType(), recordComponentDescription(component, element))
+                element.recordComponents.forEach { component ->
+                    val name = component.simpleName.toString()
+                    required += name
+                    props += toProperty(name, component.asType(), recordComponentDescription(component, element))
+                }
+
+                objectNode(element, props, required)
             }
-
-            objectNode(element, props, required)
         }
 
         return TypeRef.Ref(id)
@@ -104,19 +113,21 @@ internal class AptIntrospectionContext(
         val id = TypeId(element.qualifiedName.toString())
 
         withCycleDetection(type, id) {
-            val props = ArrayList<Property>()
-            val required = LinkedHashSet<String>()
+            buildOrGet(type, id) {
+                val props = ArrayList<Property>()
+                val required = LinkedHashSet<String>()
 
-            element.enclosedElements
-                .filterIsInstance<VariableElement>()
-                .filter { it.kind == ElementKind.FIELD && !it.modifiers.contains(Modifier.STATIC) }
-                .forEach { field ->
-                    val name = field.simpleName.toString()
-                    required += name
-                    props += toProperty(name, field.asType(), extractDescription(field))
-                }
+                element.enclosedElements
+                    .filterIsInstance<VariableElement>()
+                    .filter { it.kind == ElementKind.FIELD && !it.modifiers.contains(Modifier.STATIC) }
+                    .forEach { field ->
+                        val name = field.simpleName.toString()
+                        required += name
+                        props += toProperty(name, field.asType(), extractDescription(field))
+                    }
 
-            objectNode(element, props, required)
+                objectNode(element, props, required)
+            }
         }
 
         return TypeRef.Ref(id)
@@ -129,21 +140,23 @@ internal class AptIntrospectionContext(
         val id = TypeId(element.qualifiedName.toString())
 
         withCycleDetection(type, id) {
-            val props = ArrayList<Property>()
-            val required = LinkedHashSet<String>()
+            buildOrGet(type, id) {
+                val props = ArrayList<Property>()
+                val required = LinkedHashSet<String>()
 
-            element.enclosedElements
-                .filterIsInstance<ExecutableElement>()
-                .filter { it.kind == ElementKind.METHOD }
-                .filter { !it.modifiers.contains(Modifier.STATIC) }
-                .filter { it.parameters.isEmpty() && it.returnType.kind != TypeKind.VOID }
-                .forEach { method ->
-                    val name = propertyName(method.simpleName.toString())
-                    required += name
-                    props += toProperty(name, method.returnType, extractDescription(method))
-                }
+                element.enclosedElements
+                    .filterIsInstance<ExecutableElement>()
+                    .filter { it.kind == ElementKind.METHOD }
+                    .filter { !it.modifiers.contains(Modifier.STATIC) }
+                    .filter { it.parameters.isEmpty() && it.returnType.kind != TypeKind.VOID }
+                    .forEach { method ->
+                        val name = propertyName(method.simpleName.toString())
+                        required += name
+                        props += toProperty(name, method.returnType, extractDescription(method))
+                    }
 
-            objectNode(element, props, required)
+                objectNode(element, props, required)
+            }
         }
 
         return TypeRef.Ref(id)
@@ -179,6 +192,41 @@ internal class AptIntrospectionContext(
         } else {
             name.replaceFirstChar { it.lowercase() }
         }
+
+    /**
+     * Returns the cached node for [id] or builds and caches it via [builder].
+     *
+     * A cached node was built for another root, so its `$ref` targets are not yet
+     * registered in the current context; re-register them so each root's `$defs` stays
+     * complete. Registration recurses through [toRef], which deduplicates via
+     * [withCycleDetection], so shared subgraphs are registered exactly once per root.
+     */
+    private fun buildOrGet(
+        type: TypeMirror,
+        id: TypeId,
+        builder: () -> TypeNode,
+    ): TypeNode {
+        nodeCache[id]?.let { cached ->
+            registerRefs(cached.node)
+            return cached.node
+        }
+        return builder().also { nodeCache[id] = CachedNode(type, it) }
+    }
+
+    /**
+     * Re-registers the types referenced by [node] into the current context. The apt front
+     * end only emits object nodes whose properties reference primitives inline or other
+     * objects by id, so any other cached node kind is an unsupported invariant.
+     */
+    private fun registerRefs(node: TypeNode) {
+        val objectNode = node as? ObjectNode
+            ?: error("Unsupported cached node kind $node; registerRefs must handle all node kinds")
+        objectNode.properties.forEach { property ->
+            (property.type as? TypeRef.Ref)?.let { ref ->
+                toRef(nodeCache.getValue(ref.id).type)
+            }
+        }
+    }
 
     private companion object {
         const val GET_PREFIX: String = "get"
@@ -257,3 +305,12 @@ internal class AptIntrospectionContext(
 
     //endregion
 }
+
+/**
+ * A memoized node together with the [TypeMirror] used to build it, so cached `$ref`
+ * targets can be re-registered into a fresh root context.
+ */
+internal data class CachedNode(
+    val type: TypeMirror,
+    val node: TypeNode,
+)

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -358,6 +358,101 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
+    fun `should generate schemas for nested record shared by multiple roots`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val vendorSource = """
+            package com.example;
+
+            public record Vendor(String name, String location) {}
+        """.trimIndent()
+
+        // language=java
+        val lineItemSource = """
+            package com.example;
+
+            public record LineItem(String sku, int quantity, Vendor vendor) {}
+        """.trimIndent()
+
+        // language=java
+        val orderSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Order(LineItem item) {}
+        """.trimIndent()
+
+        // language=java
+        val invoiceSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Invoice(LineItem item) {}
+        """.trimIndent()
+
+        val outputDir =
+            compile(listOf(vendorSource, lineItemSource, orderSource, invoiceSource), tempDir)
+
+        val orderSchema =
+            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json").toFile()
+        val invoiceSchema =
+            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Invoice.json").toFile()
+
+        // language=json
+        val expectedSchema = $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Order",
+                "type": "object",
+                "properties": {
+                    "item": {
+                        "$ref": "#/$defs/com.example.LineItem"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["item"],
+                "$defs": {
+                    "com.example.LineItem": {
+                        "type": "object",
+                        "properties": {
+                            "sku": { "type": "string" },
+                            "quantity": { "type": "integer" },
+                            "vendor": {
+                                "$ref": "#/$defs/com.example.Vendor"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["sku", "quantity", "vendor"]
+                    },
+                    "com.example.Vendor": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "location": { "type": "string" }
+                        },
+                        "additionalProperties": false,
+                        "required": ["name", "location"]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        orderSchema.exists() shouldBe true
+        orderSchema.readText() shouldEqualJson expectedSchema
+
+        invoiceSchema.exists() shouldBe true
+        invoiceSchema.readText() shouldEqualJson expectedSchema.replace(
+            "\"\$id\": \"com.example.Order\"",
+            "\"\$id\": \"com.example.Invoice\"",
+        )
+    }
+
+    @Test
     fun `should not generate schema when no annotated types`(
         @TempDir tempDir: Path,
     ) {


### PR DESCRIPTION


## Description

Share a node cache across roots so nested types referenced by several roots are introspected once, re-registering cached $ref targets per root to keep $defs scoped and complete. Hoist the introspector via lazy (processingEnv is only available after init). Add CachedNode value type and fail-fast registerRefs; add cross-root shared-nested test.

Issue #74 

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [x] **No debug code**: Removed commented-out code and debug statements

