### PR TITLE
feat(apt): introspect collections, maps, arrays and type variables (#74)

### DIFF
--- a/docs/apt.md
+++ b/docs/apt.md
@@ -9,6 +9,7 @@
 * [Triggering schema generation](#triggering-schema-generation)
 * [Configuration options](#configuration-options)
 * [Generated output](#generated-output)
+  * [Extended example](#extended-example)
   * [Reading the resource at runtime](#reading-the-resource-at-runtime)
 * [Supported types](#supported-types)
 * [See Also](#see-also)
@@ -136,8 +137,9 @@ For the `Person` record above, that's `META-INF/kt-schema/schemas/com/example/Pe
 
 ```json
 {
-  "$id": "com.example.Person",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "com.example.Person",
+  "description": "A person with a first and last name and age.",
   "type": "object",
   "properties": {
     "firstName": {
@@ -153,14 +155,111 @@ For the `Person` record above, that's `META-INF/kt-schema/schemas/com/example/Pe
       "description": "Age of the person in years"
     }
   },
-  "required": ["firstName", "lastName", "age"],
   "additionalProperties": false,
-  "description": "A person with a first and last name and age."
+  "required": ["firstName", "lastName", "age"]
 }
 ```
 
 This is the same [Draft 2020-12 JSON Schema model](../kt-schema-json) the KSP processor produces — both reuse
 the same `TypeGraphToJsonSchemaTransformer`, so `$id`/`$defs`/`$ref`/nullability handling is identical.
+
+### Extended example
+
+Beyond plain scalars and nested records, the processor handles collections, maps, arrays, `Object` and type
+variables. Consider an `Order` record referencing an `Address`:
+
+```java
+import me.kpavlov.kt.schema.Description;
+import me.kpavlov.kt.schema.Schema;
+
+@Schema
+@Description("A customer order with tags, quantities, price points and billing address.")
+public record Order(
+        @Description("Unique order identifier") String id,
+        @Description("Tags attached to the order") java.util.Set<String> tags,
+        @Description("Line item quantities by SKU") java.util.Map<String, Integer> quantities,
+        @Description("Historical price points") double[] prices,
+        @Description("Free-form metadata") Object metadata,
+        @Description("Billing address") Address address) {
+}
+```
+
+```java
+@Schema
+public record Address(
+        @Description("City part of the address") String city,
+        @Description("Street part of the address") String street) {
+}
+```
+
+This generates `META-INF/kt-schema/schemas/com/example/Order.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "com.example.Order",
+  "description": "A customer order with tags, quantities, price points and billing address.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique order identifier"
+    },
+    "tags": {
+      "type": "array",
+      "description": "Tags attached to the order",
+      "items": {
+        "type": "string"
+      }
+    },
+    "quantities": {
+      "type": "object",
+      "description": "Line item quantities by SKU",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "prices": {
+      "type": "array",
+      "description": "Historical price points",
+      "items": {
+        "type": "number"
+      }
+    },
+    "metadata": {
+      "description": "Free-form metadata"
+    },
+    "address": {
+      "$ref": "#/$defs/com.example.Address",
+      "description": "Billing address"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id", "tags", "quantities", "prices", "metadata", "address"],
+  "$defs": {
+    "com.example.Address": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string",
+          "description": "City part of the address"
+        },
+        "street": {
+          "type": "string",
+          "description": "Street part of the address"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["city", "street"]
+    }
+  }
+}
+```
+
+Collections (`List`, `Set`, `Collection`, and subclasses thereof) map to `array` with `items`, `Map` maps to
+`object` with `additionalProperties`, arrays nest `items` per dimension, `Object` emits an empty schema `{}`
+(accepts any value), and nested records become `$ref`/`$defs` entries. `Address` is also emitted as its own
+root resource because it is `@Schema`-annotated.
 
 ### Reading the resource at runtime
 
@@ -181,9 +280,15 @@ try (InputStream in = Person.class.getClassLoader()
 - Java `interface`s — no-arg methods map to required properties, named per the JavaBeans convention
   (`getName()` → `name`, `isActive()` → `active`, and a bare `name()` accessor stays `name`)
 - `String`, boxed and primitive numeric/boolean types
+- `Iterable`-derived collections (`List`, `Set`, `Collection`, custom subclasses) — emitted as `array` with
+  `items` describing the element type
+- `Map` — emitted as `object` with `additionalProperties` describing the value type
+- Arrays, including multi-dimensional — emitted as `array` with `items` nested per dimension
+- `java.lang.Object` — emitted as an empty schema `{}` accepting any value
+- Type variables: upper-bounded (`T extends Number`) resolve to their bound; unbounded (`T`) emit `{}`
 - Nested records/classes/interfaces, emitted as `$ref`/`$defs` and deduplicated, same as KSP
 
-Not yet supported: enums, sealed interfaces/classes, generics, and collections/maps. Processing an
+Not yet supported: enums and sealed class hierarchies (polymorphic `oneOf` with discriminators). Processing an
 unsupported type fails the build with a descriptive error rather than emitting an incomplete schema.
 
 > [!NOTE]

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -47,7 +47,7 @@ public class JsonSchemaProcessor : AbstractProcessor() {
      * Shared across roots so nested types referenced by several roots are introspected
      * once; `processingEnv` is only available after `init()`, hence the lazy delegate.
      */
-    private val introspector by lazy { AptClassIntrospector(processingEnv.typeUtils) }
+    private val introspector by lazy { AptClassIntrospector(processingEnv) }
 
     private val transformer =
         TypeGraphToJsonSchemaTransformer(

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -5,14 +5,15 @@ import me.kpavlov.kt.schema.generator.core.ir.SchemaIntrospector
 import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
 import me.kpavlov.kt.schema.generator.core.ir.TypeId
 import me.kpavlov.kt.schema.generator.core.ir.TypeNode
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.TypeElement
-import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Types
 
 /**
  * Java-APT-backed schema IR introspector. Supports records, plain classes and interfaces
- * with primitive/String/boxed field types and nested references; generics/enums/sealed
- * hierarchies are not yet supported.
+ * with primitive/String/boxed field types, nested references, collections, maps, arrays
+ * and upper-bounded type variables; enums and sealed/polymorphic hierarchies are not yet
+ * supported.
  *
  * A fresh [AptIntrospectionContext] is created per root so `$defs` stay scoped to the
  * types reachable from that root; [nodeCache] memoizes built nodes across roots so nested
@@ -21,11 +22,17 @@ import javax.lang.model.util.Types
  * @author Konstantin Pavlov
  */
 internal class AptClassIntrospector(
-    private val types: Types,
+    processingEnv: ProcessingEnvironment,
 ) : SchemaIntrospector<TypeElement, Unit> {
     //region Configuration
 
     override val config = Unit
+
+    /**
+     * The processing environment's type utils. Bound to the same round as the [TypeElement]s
+     * handed to [introspect], so elements and utilities always come from one [ProcessingEnvironment].
+     */
+    private val types: Types = processingEnv.typeUtils
 
     private val nodeCache: MutableMap<TypeId, CachedNode> = mutableMapOf()
 

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -2,8 +2,11 @@
 package me.kpavlov.kt.schema.apt.ir
 
 import me.kpavlov.kt.schema.generator.core.InternalSchemaGeneratorApi
+import me.kpavlov.kt.schema.generator.core.ir.AnyNode
 import me.kpavlov.kt.schema.generator.core.ir.BaseIntrospectionContext
 import me.kpavlov.kt.schema.generator.core.ir.Introspections
+import me.kpavlov.kt.schema.generator.core.ir.ListNode
+import me.kpavlov.kt.schema.generator.core.ir.MapNode
 import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
@@ -18,16 +21,22 @@ import javax.lang.model.element.Modifier
 import javax.lang.model.element.RecordComponentElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
+import javax.lang.model.type.ArrayType
+import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.TypeKind
 import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.TypeVariable
+import javax.lang.model.type.WildcardType
 import javax.lang.model.util.Types
 
 /**
  * Introspection context for the Java annotation-processor (JSR 269) front end.
  *
- * Supports Java records, plain classes and interfaces with primitive/boxed/String fields
- * and nested references. Reference types are treated as non-nullable/required: Java has
- * no notion of optionality/default values, so every property is required.
+ * Supports Java records, plain classes and interfaces with primitive/boxed/String fields,
+ * nested references, collections (`List`/`Set`/`Collection`/`Iterable`), maps (`Map`),
+ * arrays, `Object` and upper-bounded type variables. Reference types are treated as
+ * non-nullable/required: Java has no notion of optionality/default values, so every property
+ * is required.
  *
  * A fresh context is created per root type so `$defs` stay scoped to the types reachable
  * from that root; [nodeCache] memoizes built nodes across roots so nested types shared
@@ -46,15 +55,52 @@ internal class AptIntrospectionContext(
 
     override fun toRef(type: TypeMirror): TypeRef {
         primitiveKindFor(type)?.let { return TypeRef.Inline(PrimitiveNode(it)) }
+        return when (type.kind) {
+            TypeKind.ARRAY -> handleArray(type)
+            TypeKind.TYPEVAR -> handleTypeVariable(type)
+            TypeKind.DECLARED -> handleDeclared(type as DeclaredType) ?: handleReferenceType(type)
+            else -> handleReferenceType(type)
+        }
+    }
 
-        return handleRecord(type)
+    /**
+     * Handles `Object`, map and iterable-derived declared types; returns null for anything
+     * else so [toRef] falls through to [handleReferenceType].
+     */
+    private fun handleDeclared(type: DeclaredType): TypeRef? {
+        val element = asTypeElement(type) ?: return null
+        return when {
+            element.qualifiedName.toString() == "java.lang.Object" -> TypeRef.Inline(AnyNode())
+            containerKindOf(type) == ContainerKind.MAP -> handleMap(type)
+            containerKindOf(type) == ContainerKind.ITERABLE -> handleList(type)
+            else -> null
+        }
+    }
+
+    /**
+     * Resolves a type variable to its upper bound, so `T extends Foo` introspects as `Foo`
+     * and an unbounded `T` (whose bound is `Object`) introspects as [AnyNode].
+     */
+    private fun handleTypeVariable(type: TypeMirror): TypeRef {
+        val upperBound = (type as TypeVariable).upperBound
+        return when (upperBound.kind) {
+            TypeKind.DECLARED -> toRef(upperBound)
+            else -> error(
+                "Unsupported type parameter $type for kt-schema-apt " +
+                    "(only upper-bounded type variables are supported): $type",
+            )
+        }
+    }
+
+    private fun handleReferenceType(type: TypeMirror): TypeRef =
+        handleRecord(type)
             ?: handleClass(type)
             ?: handleInterface(type)
             ?: error(
                 "Unsupported type for kt-schema-apt " +
-                    "(only records, classes, interfaces, primitives and String are supported): $type",
+                    "(only records, classes, interfaces, primitives, String, collections, maps and arrays " +
+                    "are supported): $type",
             )
-    }
 
     private fun primitiveKindFor(type: TypeMirror): PrimitiveKind? =
         when (type.kind) {
@@ -81,6 +127,87 @@ internal class AptIntrospectionContext(
         }
 
     private fun asTypeElement(type: TypeMirror): TypeElement? = types.asElement(type) as? TypeElement
+
+    /**
+     * Converts an array type to an inline [ListNode] of its component type, so `int[]`
+     * and `String[][]` map to `{"type": "array", "items": ...}` in JSON Schema.
+     */
+    private fun handleArray(type: TypeMirror): TypeRef =
+        TypeRef.Inline(ListNode(toRef((type as ArrayType).componentType)))
+
+    /**
+     * Converts an `Iterable`-derived type (`List`, `Set`, `Collection`, ...) to an inline
+     * [ListNode]. Unbounded wildcards and raw types fall back to a STRING element, mirroring
+     * the reflection introspector's star-projection handling.
+     */
+    private fun handleList(type: DeclaredType): TypeRef {
+        val elementRef =
+            type.typeArguments.firstOrNull()?.resolveWildcard()?.let(::toRef)
+                ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING))
+        return TypeRef.Inline(ListNode(elementRef))
+    }
+
+    /**
+     * Converts a `Map`-derived type to an inline [MapNode]. Unbounded wildcards and raw
+     * types fall back to a STRING key/value, mirroring the reflection introspector's
+     * star-projection handling.
+     */
+    private fun handleMap(type: DeclaredType): TypeRef {
+        val keyRef =
+            type.typeArguments.getOrNull(0)?.resolveWildcard()?.let(::toRef)
+                ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING))
+        val valueRef =
+            type.typeArguments.getOrNull(1)?.resolveWildcard()?.let(::toRef)
+                ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING))
+        return TypeRef.Inline(MapNode(keyRef, valueRef))
+    }
+
+    /**
+     * The container kind of a `Map`/`Iterable`-derived declared type, or null otherwise.
+     */
+    private enum class ContainerKind { MAP, ITERABLE }
+
+    /**
+     * Returns the [ContainerKind] of [type], walking the supertype hierarchy (so `ArrayList`
+     * matches `java.util.List`/`java.lang.Iterable`). Memoized by qualified name — a type is
+     * or isn't a container regardless of its type arguments — so each hierarchy walk happens
+     * once per type instead of once per field occurrence.
+     */
+    private val containerKinds: MutableMap<String, ContainerKind?> = mutableMapOf()
+
+    private fun containerKindOf(type: DeclaredType): ContainerKind? {
+        val element = asTypeElement(type) ?: return null
+        val name = element.qualifiedName.toString()
+        if (name !in containerKinds) {
+            containerKinds[name] = computeContainerKind(type, name)
+        }
+        return containerKinds[name]
+    }
+
+    private fun computeContainerKind(
+        type: DeclaredType,
+        name: String,
+    ): ContainerKind? =
+        when (name) {
+            "java.lang.Object" -> null
+            "java.util.Map" -> ContainerKind.MAP
+            "java.lang.Iterable" -> ContainerKind.ITERABLE
+            else ->
+                types.directSupertypes(type)
+                    .filterIsInstance<DeclaredType>()
+                    .firstNotNullOfOrNull(::containerKindOf)
+        }
+
+    /**
+     * Resolves a wildcard type argument to its declared bound (`? extends Foo` → `Foo`,
+     * `? super Bar` → `Bar`), leaving concrete types untouched. Unbounded wildcards
+     * resolve to null so callers can apply a fallback.
+     */
+    private fun TypeMirror.resolveWildcard(): TypeMirror? =
+        when (this) {
+            is WildcardType -> extendsBound ?: superBound
+            else -> this
+        }
 
     private fun handleRecord(type: TypeMirror): TypeRef? {
         val element = asTypeElement(type)
@@ -215,16 +342,31 @@ internal class AptIntrospectionContext(
 
     /**
      * Re-registers the types referenced by [node] into the current context. The apt front
-     * end only emits object nodes whose properties reference primitives inline or other
-     * objects by id, so any other cached node kind is an unsupported invariant.
+     * end only caches object nodes, so any other cached node kind is an unsupported
+     * invariant. References are registered through inline list/map nodes as well, so a
+     * cached `List<Shared>` property still pulls `Shared` into a fresh root's `$defs`.
      */
     private fun registerRefs(node: TypeNode) {
-        val objectNode = node as? ObjectNode
-            ?: error("Unsupported cached node kind $node; registerRefs must handle all node kinds")
+        val objectNode =
+            node as? ObjectNode
+                ?: error("Unsupported cached node kind $node; registerRefs must handle all node kinds")
         objectNode.properties.forEach { property ->
-            (property.type as? TypeRef.Ref)?.let { ref ->
-                toRef(nodeCache.getValue(ref.id).type)
-            }
+            registerRefs(property.type)
+        }
+    }
+
+    private fun registerRefs(typeRef: TypeRef) {
+        when (typeRef) {
+            is TypeRef.Ref -> toRef(nodeCache.getValue(typeRef.id).type)
+            is TypeRef.Inline ->
+                when (val node = typeRef.node) {
+                    is ListNode -> registerRefs(node.element)
+                    is MapNode -> {
+                        registerRefs(node.key)
+                        registerRefs(node.value)
+                    }
+                    else -> Unit
+                }
         }
     }
 

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -69,10 +69,11 @@ internal class AptIntrospectionContext(
      */
     private fun handleDeclared(type: DeclaredType): TypeRef? {
         val element = asTypeElement(type) ?: return null
+        val container = containerKindOf(type)
         return when {
             element.qualifiedName.toString() == "java.lang.Object" -> TypeRef.Inline(AnyNode())
-            containerKindOf(type) == ContainerKind.MAP -> handleMap(type)
-            containerKindOf(type) == ContainerKind.ITERABLE -> handleList(type)
+            container?.kind == ContainerKind.MAP -> handleMap(container.type)
+            container?.kind == ContainerKind.ITERABLE -> handleList(container.type)
             else -> null
         }
     }
@@ -87,7 +88,7 @@ internal class AptIntrospectionContext(
             TypeKind.DECLARED -> toRef(upperBound)
             else -> error(
                 "Unsupported type parameter $type for kt-schema-apt " +
-                    "(only upper-bounded type variables are supported): $type",
+                    "(only upper-bounded type variables are supported)",
             )
         }
     }
@@ -136,9 +137,11 @@ internal class AptIntrospectionContext(
         TypeRef.Inline(ListNode(toRef((type as ArrayType).componentType)))
 
     /**
-     * Converts an `Iterable`-derived type (`List`, `Set`, `Collection`, ...) to an inline
-     * [ListNode]. Unbounded wildcards and raw types fall back to a STRING element, mirroring
-     * the reflection introspector's star-projection handling.
+     * Converts an `Iterable`-derived declared type to an inline [ListNode]. [type] is the
+     * supertype that declares the interface (resolved by [containerKindOf]), so type
+     * arguments are read from it rather than the original subtype. Unbounded wildcards and
+     * raw types fall back to a STRING element, mirroring the reflection introspector's
+     * star-projection handling.
      */
     private fun handleList(type: DeclaredType): TypeRef {
         val elementRef =
@@ -148,9 +151,10 @@ internal class AptIntrospectionContext(
     }
 
     /**
-     * Converts a `Map`-derived type to an inline [MapNode]. Unbounded wildcards and raw
-     * types fall back to a STRING key/value, mirroring the reflection introspector's
-     * star-projection handling.
+     * Converts a `Map`-derived declared type to an inline [MapNode]. [type] is the supertype
+     * that declares the interface (resolved by [containerKindOf]), so type arguments are read
+     * from it rather than the original subtype. Unbounded wildcards and raw types fall back
+     * to a STRING key/value, mirroring the reflection introspector's star-projection handling.
      */
     private fun handleMap(type: DeclaredType): TypeRef {
         val keyRef =
@@ -168,20 +172,30 @@ internal class AptIntrospectionContext(
     private enum class ContainerKind { MAP, ITERABLE }
 
     /**
-     * Returns the [ContainerKind] of [type], walking the supertype hierarchy (so `ArrayList`
-     * matches `java.util.List`/`java.lang.Iterable`). Memoized by qualified name — a type is
-     * or isn't a container regardless of its type arguments — so each hierarchy walk happens
-     * once per type instead of once per field occurrence.
+     * A container kind paired with the declared type that declares the matching
+     * `java.util.Map`/`java.lang.Iterable` interface, so type arguments can be read from
+     * the resolved supertype rather than the original subtype (e.g. `ArrayList<String>` for
+     * a raw `MyList extends ArrayList<String>` field).
      */
+    private data class ContainerInfo(
+        val kind: ContainerKind,
+        val type: DeclaredType,
+    )
+
+    /** Container kinds are memoized by qualified name. */
     private val containerKinds: MutableMap<String, ContainerKind?> = mutableMapOf()
 
-    private fun containerKindOf(type: DeclaredType): ContainerKind? {
+    /**
+     * Returns the [ContainerInfo] of [type], walking the supertype hierarchy (so `ArrayList`
+     * matches `java.lang.Iterable`). Whether a type is a container does not depend on its type
+     * arguments, so the kind is memoized by qualified name. The matched declared supertype,
+     * however, is resolved per call so its type arguments reflect the concrete usage.
+     */
+    private fun containerKindOf(type: DeclaredType): ContainerInfo? {
         val element = asTypeElement(type) ?: return null
         val name = element.qualifiedName.toString()
-        if (name !in containerKinds) {
-            containerKinds[name] = computeContainerKind(type, name)
-        }
-        return containerKinds[name]
+        return containerKinds.getOrPut(name) { computeContainerKind(type, name) }
+            ?.let { kind -> ContainerInfo(kind, resolveContainerType(type, kind) ?: type) }
     }
 
     private fun computeContainerKind(
@@ -196,7 +210,24 @@ internal class AptIntrospectionContext(
                 types.directSupertypes(type)
                     .filterIsInstance<DeclaredType>()
                     .firstNotNullOfOrNull(::containerKindOf)
+                    ?.kind
         }
+
+    private fun resolveContainerType(
+        type: DeclaredType,
+        kind: ContainerKind,
+    ): DeclaredType? {
+        val element = asTypeElement(type) ?: return null
+        return when (element.qualifiedName.toString()) {
+            "java.util.Map" -> if (kind == ContainerKind.MAP) type else null
+            "java.lang.Iterable" -> if (kind == ContainerKind.ITERABLE) type else null
+            "java.lang.Object" -> null
+            else ->
+                types.directSupertypes(type)
+                    .filterIsInstance<DeclaredType>()
+                    .firstNotNullOfOrNull { resolveContainerType(it, kind) }
+        }
+    }
 
     /**
      * Resolves a wildcard type argument to its declared bound (`? extends Foo` → `Foo`,

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JavaSources.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JavaSources.kt
@@ -1,0 +1,25 @@
+package me.kpavlov.kt.schema.apt
+
+import java.net.URI
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+
+/**
+ * Builds in-memory [JavaFileObject]s for compiler tests, inferring the fully qualified
+ * name from the source so `javac` can process sources written as strings.
+ */
+internal object JavaSources {
+    fun of(code: String): JavaFileObject {
+        val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
+        val cls =
+            Regex("""(?:public\s+)?(?:record|class|interface|enum)\s+(\w+)""").find(code)?.groupValues?.get(1)
+                ?: error("Cannot infer class name from source:\n$code")
+        val fqn = "$pkg.$cls"
+        return object : SimpleJavaFileObject(
+            URI.create("string:///${fqn.replace('.', '/')}${JavaFileObject.Kind.SOURCE.extension}"),
+            JavaFileObject.Kind.SOURCE,
+        ) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean) = code
+        }
+    }
+}

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -453,6 +453,83 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
+    fun `should generate schema for record with collections arrays and nested object`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val addressSource = """
+            package com.example;
+
+            public record Address(String city) {}
+        """.trimIndent()
+
+        // language=java
+        val orderSource = """
+            package com.example;
+
+            import java.util.List;
+            import java.util.Map;
+
+            public record Order(List<String> tags, Map<String, Integer> counts, int[] values, Address address) {}
+        """.trimIndent()
+
+        val outputDir =
+            compile(
+                sources = listOf(addressSource, orderSource),
+                tempDir = tempDir,
+                options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            )
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Order",
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "counts": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer"
+                        }
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "address": {
+                        "$ref": "#/$defs/com.example.Address"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["tags", "counts", "values", "address"],
+                "$defs": {
+                    "com.example.Address": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["city"]
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+
+    @Test
     fun `should not generate schema when no annotated types`(
         @TempDir tempDir: Path,
     ) {

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -7,11 +7,9 @@ import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.io.StringWriter
-import java.net.URI
 import java.nio.file.Path
 import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
-import javax.tools.SimpleJavaFileObject
 import javax.tools.ToolProvider
 
 class JsonSchemaProcessorTest {
@@ -530,6 +528,311 @@ class JsonSchemaProcessorTest {
     }
 
     @Test
+    fun `should generate schema for record with set and collection fields`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Bundle(
+                java.util.Set<String> tags,
+                java.util.Collection<Integer> scores
+            ) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Bundle.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Bundle",
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scores": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["tags", "scores"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with multi-dimensional array field`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record ArraysHolder(double[][] matrix) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/ArraysHolder.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.ArraysHolder",
+                "type": "object",
+                "properties": {
+                    "matrix": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["matrix"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with nested collections`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Nested(
+                java.util.List<java.util.List<String>> matrix,
+                java.util.Map<String, java.util.List<Integer>> grouped,
+                java.util.List<java.util.Map<String, java.lang.Boolean>> flags
+            ) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Nested.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Nested",
+                "type": "object",
+                "properties": {
+                    "matrix": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "grouped": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "flags": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["matrix", "grouped", "flags"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with java lang Object component`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Wrapper(Object payload) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Wrapper.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Wrapper",
+                "type": "object",
+                "properties": {
+                    "payload": {}
+                },
+                "additionalProperties": false,
+                "required": ["payload"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with upper bounded type variable`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Box<T extends Number>(T value) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Box.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Box",
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "$ref": "#/$defs/java.lang.Number"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["value"],
+                "$defs": {
+                    "java.lang.Number": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": false
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with unbounded type variable`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Box<T>(T value) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Box.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Box",
+                "type": "object",
+                "properties": {
+                    "value": {}
+                },
+                "additionalProperties": false,
+                "required": ["value"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record with iterable subclass component`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val namesSource = """
+            package com.example;
+
+            class Names extends java.util.ArrayList<String> {}
+        """.trimIndent()
+
+        // language=java
+        val orderSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Order(Names names) {}
+        """.trimIndent()
+
+        val outputDir = compile(listOf(namesSource, orderSource), tempDir)
+
+        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json")
+        schemaFile.toFile().exists() shouldBe true
+        // language=json
+        schemaFile.toFile().readText() shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Order",
+                "type": "object",
+                "properties": {
+                    "names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["names"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
     fun `should not generate schema when no annotated types`(
         @TempDir tempDir: Path,
     ) {
@@ -856,19 +1159,7 @@ class JsonSchemaProcessorTest {
         val outputDir = tempDir.resolve("classes")
         outputDir.toFile().mkdirs()
 
-        val sourceFiles = sources.map { code ->
-            val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
-            val cls =
-                Regex("""(?:public\s+)?(?:record|class|interface|enum)\s+(\w+)""").find(code)?.groupValues?.get(1)
-                    ?: error("Cannot infer class name from source:\n$code")
-            val fqn = "$pkg.$cls"
-            object : SimpleJavaFileObject(
-                URI.create("string:///${fqn.replace('.', '/')}${JavaFileObject.Kind.SOURCE.extension}"),
-                JavaFileObject.Kind.SOURCE,
-            ) {
-                override fun getCharContent(ignoreEncodingErrors: Boolean) = code
-            }
-        }
+        val sourceFiles = sources.map(JavaSources::of)
 
         val allOptions = mutableListOf("-d", outputDir.toFile().absolutePath)
         allOptions.addAll(options)

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -1,8 +1,10 @@
 package me.kpavlov.kt.schema.apt.ir
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import me.kpavlov.kt.schema.apt.JavaSources
 import me.kpavlov.kt.schema.generator.core.ir.AnyNode
 import me.kpavlov.kt.schema.generator.core.ir.ListNode
 import me.kpavlov.kt.schema.generator.core.ir.MapNode
@@ -16,16 +18,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.io.StringWriter
-import java.net.URI
 import java.nio.file.Files
 import javax.annotation.processing.AbstractProcessor
-import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
-import javax.tools.SimpleJavaFileObject
 import javax.tools.ToolProvider
 
 class AptClassIntrospectorTest {
@@ -54,18 +53,20 @@ class AptClassIntrospectorTest {
             )
 
         val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        rootRef.id.value shouldBe "com.example.Company"
-        rootRef.nullable shouldBe false
+        assertSoftly(rootRef) {
+            id.value shouldBe "com.example.Company"
+            nullable shouldBe false
+        }
 
         val companyNode = graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<ObjectNode>()
-        companyNode.required.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
-
-        val props = companyNode.properties.associateBy { it.name }
-        props.keys.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
-
-        props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
-        props.getValue("founded").type.shouldBePrimitive(PrimitiveKind.INT)
-        props.getValue("active").type.shouldBePrimitive(PrimitiveKind.BOOLEAN)
+        assertSoftly(companyNode) {
+            required.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
+            val props = properties.associateBy { it.name }
+            props.keys.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
+            props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
+            props.getValue("founded").type.shouldBePrimitive(PrimitiveKind.INT)
+            props.getValue("active").type.shouldBePrimitive(PrimitiveKind.BOOLEAN)
+        }
     }
 
     @ParameterizedTest(name = "should map {0} to {1}")
@@ -182,14 +183,16 @@ class AptClassIntrospectorTest {
 
         val props = graph.rootNode().properties.associateBy { it.name }
 
-        props.getValue("names").type.shouldBeList { element ->
-            element.shouldBePrimitive(PrimitiveKind.STRING)
-        }
-        props.getValue("scores").type.shouldBeList { element ->
-            element.shouldBePrimitive(PrimitiveKind.INT)
-        }
-        props.getValue("ratios").type.shouldBeList { element ->
-            element.shouldBePrimitive(PrimitiveKind.DOUBLE)
+        assertSoftly(props) {
+            getValue("names").type.shouldBeList { element ->
+                element.shouldBePrimitive(PrimitiveKind.STRING)
+            }
+            getValue("scores").type.shouldBeList { element ->
+                element.shouldBePrimitive(PrimitiveKind.INT)
+            }
+            getValue("ratios").type.shouldBeList { element ->
+                element.shouldBePrimitive(PrimitiveKind.DOUBLE)
+            }
         }
     }
 
@@ -230,11 +233,13 @@ class AptClassIntrospectorTest {
 
         val props = graph.rootNode().properties.associateBy { it.name }
 
-        props.getValue("names").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
-        props.getValue("counts").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
-        props.getValue("boxed").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
-        props.getValue("matrix").type.shouldBeList { nested ->
-            nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.DOUBLE) }
+        assertSoftly(props) {
+            getValue("names").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
+            getValue("counts").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
+            getValue("boxed").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
+            getValue("matrix").type.shouldBeList { nested ->
+                nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.DOUBLE) }
+            }
         }
     }
 
@@ -256,18 +261,20 @@ class AptClassIntrospectorTest {
 
         val props = graph.rootNode().properties.associateBy { it.name }
 
-        props.getValue("matrix").type.shouldBeList { nested ->
-            nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
-        }
-        props.getValue("grouped").type.shouldBeMap(
-            key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
-            value = { value -> value.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) } },
-        )
-        props.getValue("flags").type.shouldBeList { element ->
-            element.shouldBeMap(
+        assertSoftly(props) {
+            getValue("matrix").type.shouldBeList { nested ->
+                nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
+            }
+            getValue("grouped").type.shouldBeMap(
                 key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
-                value = { it.shouldBePrimitive(PrimitiveKind.BOOLEAN) },
+                value = { value -> value.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) } },
             )
+            getValue("flags").type.shouldBeList { element ->
+                element.shouldBeMap(
+                    key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
+                    value = { it.shouldBePrimitive(PrimitiveKind.BOOLEAN) },
+                )
+            }
         }
     }
 
@@ -298,10 +305,12 @@ class AptClassIntrospectorTest {
             )
 
         val node = graph.rootNode()
-        node.required.shouldContainExactlyInAnyOrder(setOf("name", "age"))
-        val props = node.properties.associateBy { it.name }
-        props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
-        props.getValue("age").type.shouldBePrimitive(PrimitiveKind.INT)
+        assertSoftly(node) {
+            required.shouldContainExactlyInAnyOrder(setOf("name", "age"))
+            val props = properties.associateBy { it.name }
+            props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
+            props.getValue("age").type.shouldBePrimitive(PrimitiveKind.INT)
+        }
     }
 
     @Test
@@ -340,8 +349,64 @@ class AptClassIntrospectorTest {
         root: String,
         vararg sources: String,
     ): TypeGraph {
-        val fixture = introspectionFixture(root, *sources)
-        return AptClassIntrospector(fixture.processingEnv).introspect(fixture.typeElement)
+        val compiler = ToolProvider.getSystemJavaCompiler()
+            ?: error("No system Java compiler available — run on JDK, not JRE")
+
+        val rootDir = Files.createTempDirectory("kt-schema-apt-test")
+        val outputDir = rootDir.resolve("classes").also { Files.createDirectories(it) }
+        try {
+            val diagnostics = DiagnosticCollector<JavaFileObject>()
+            val sourceFiles = sources.map(JavaSources::of)
+
+            val processor =
+                object : AbstractProcessor() {
+                    var capturedGraph: TypeGraph? = null
+
+                    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
+
+                    override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf("*")
+
+                    override fun process(
+                        annotations: MutableSet<out TypeElement>,
+                        roundEnv: RoundEnvironment,
+                    ): Boolean {
+                        if (capturedGraph == null) {
+                            val element =
+                                roundEnv.rootElements
+                                    .filterIsInstance<TypeElement>()
+                                    .firstOrNull { it.qualifiedName.contentEquals(root) }
+                            if (element != null) {
+                                // Introspect while the JSR 269 round is active so the elements
+                                // and processing environment stay valid.
+                                capturedGraph = AptClassIntrospector(processingEnv).introspect(element)
+                            }
+                        }
+                        return false
+                    }
+                }
+
+            val writer = StringWriter()
+            val task =
+                compiler.getTask(
+                    writer,
+                    null,
+                    diagnostics,
+                    listOf("-d", outputDir.toFile().absolutePath),
+                    null,
+                    sourceFiles,
+                )
+            task.setProcessors(listOf(processor))
+
+            val success = task.call()
+            if (!success) {
+                val messages = diagnostics.diagnostics.joinToString("\n") { it.toString() }
+                error("Compilation failed:\n$messages\nCompiler output:\n$writer")
+            }
+
+            return processor.capturedGraph ?: error("Type $root not found in compilation")
+        } finally {
+            rootDir.toFile().deleteRecursively()
+        }
     }
 
     private fun javaClass(
@@ -398,85 +463,6 @@ class AptClassIntrospectorTest {
         }
     }
 
-    private data class IntrospectionFixture(
-        val typeElement: TypeElement,
-        val processingEnv: ProcessingEnvironment,
-    )
-
-    private fun introspectionFixture(
-        root: String,
-        vararg sources: String,
-    ): IntrospectionFixture {
-        val compiler = ToolProvider.getSystemJavaCompiler()
-            ?: error("No system Java compiler available — run on JDK, not JRE")
-
-        val rootDir = Files.createTempDirectory("kt-schema-apt-test")
-        val outputDir = rootDir.resolve("classes").also { Files.createDirectories(it) }
-        try {
-            val diagnostics = DiagnosticCollector<JavaFileObject>()
-
-            val sourceFiles = sources.map { code ->
-                val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
-                val cls =
-                    Regex("""(?:public\s+)?(?:record|class|interface|enum)\s+(\w+)""").find(code)?.groupValues?.get(1)
-                        ?: error("Cannot infer class name from source:\n$code")
-                val fqn = "$pkg.$cls"
-                object : SimpleJavaFileObject(
-                    URI.create("string:///${fqn.replace('.', '/')}${JavaFileObject.Kind.SOURCE.extension}"),
-                    JavaFileObject.Kind.SOURCE,
-                ) {
-                    override fun getCharContent(ignoreEncodingErrors: Boolean) = code
-                }
-            }
-
-            val processor =
-                object : AbstractProcessor() {
-                    var captured: IntrospectionFixture? = null
-
-                    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
-
-                    override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf("*")
-
-                    override fun process(
-                        annotations: MutableSet<out TypeElement>,
-                        roundEnv: RoundEnvironment,
-                    ): Boolean {
-                        if (captured == null) {
-                            val element =
-                                roundEnv.rootElements
-                                    .filterIsInstance<TypeElement>()
-                                    .firstOrNull { it.qualifiedName.contentEquals(root) }
-                            if (element != null) {
-                                captured = IntrospectionFixture(element, processingEnv)
-                            }
-                        }
-                        return false
-                    }
-                }
-
-            val writer = StringWriter()
-            val task =
-                compiler.getTask(
-                    writer,
-                    null,
-                    diagnostics,
-                    listOf("-d", outputDir.toFile().absolutePath),
-                    null,
-                    sourceFiles,
-                )
-            task.setProcessors(listOf(processor))
-
-            val success = task.call()
-            if (!success) {
-                val messages = diagnostics.diagnostics.joinToString("\n") { it.toString() }
-                error("Compilation failed:\n$messages\nCompiler output:\n$writer")
-            }
-
-            return processor.captured ?: error("Type $root not found in compilation")
-        } finally {
-            rootDir.toFile().deleteRecursively()
-        }
-    }
 
     //endregion
 }

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -1,0 +1,482 @@
+package me.kpavlov.kt.schema.apt.ir
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import me.kpavlov.kt.schema.generator.core.ir.AnyNode
+import me.kpavlov.kt.schema.generator.core.ir.ListNode
+import me.kpavlov.kt.schema.generator.core.ir.MapNode
+import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
+import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
+import me.kpavlov.kt.schema.generator.core.ir.TypeId
+import me.kpavlov.kt.schema.generator.core.ir.TypeRef
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import java.io.StringWriter
+import java.net.URI
+import java.nio.file.Files
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.TypeElement
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+import javax.tools.ToolProvider
+
+class AptClassIntrospectorTest {
+    //region test cases
+
+    @Test
+    fun `introspects plain class instance fields and excludes static fields`() {
+        val graph =
+            graph(
+                root = "com.example.Company",
+                javaClass(
+                    "com.example",
+                    "Company",
+                    """
+                        private String name;
+                        private int founded;
+                        private boolean active;
+                        private static final String VERSION = "1.0";
+                        public Company(String name, int founded, boolean active) {
+                            this.name = name;
+                            this.founded = founded;
+                            this.active = active;
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        rootRef.id.value shouldBe "com.example.Company"
+        rootRef.nullable shouldBe false
+
+        val companyNode = graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<ObjectNode>()
+        companyNode.required.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
+
+        val props = companyNode.properties.associateBy { it.name }
+        props.keys.shouldContainExactlyInAnyOrder(setOf("name", "founded", "active"))
+
+        props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
+        props.getValue("founded").type.shouldBePrimitive(PrimitiveKind.INT)
+        props.getValue("active").type.shouldBePrimitive(PrimitiveKind.BOOLEAN)
+    }
+
+    @ParameterizedTest(name = "should map {0} to {1}")
+    @CsvSource(
+        "byte, INT",
+        "short, INT",
+        "int, INT",
+        "long, LONG",
+        "float, FLOAT",
+        "double, DOUBLE",
+        "boolean, BOOLEAN",
+        "char, STRING",
+        "java.lang.String, STRING",
+        "java.lang.Byte, INT",
+        "java.lang.Short, INT",
+        "java.lang.Integer, INT",
+        "java.lang.Long, LONG",
+        "java.lang.Float, FLOAT",
+        "java.lang.Double, DOUBLE",
+        "java.lang.Boolean, BOOLEAN",
+        "java.lang.Character, STRING",
+    )
+    fun `should map java scalar types to primitive kinds`(
+        javaType: String,
+        expectedKind: String,
+    ) {
+        val graph =
+            graph(
+                root = "com.example.Scalars",
+                javaClass(
+                    "com.example",
+                    "Scalars",
+                    """
+                        private $javaType value;
+                        public Scalars($javaType value) {
+                            this.value = value;
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+        graph.rootNode().properties.single().type.shouldBePrimitive(PrimitiveKind.valueOf(expectedKind))
+    }
+
+    @Test
+    fun `introspects nested object field as ref with object node registered in graph`() {
+        val graph =
+            graph(
+                root = "com.example.Person",
+                javaClass(
+                    "com.example",
+                    "Address",
+                    """
+                        public String city;
+                        public String street;
+                    """.trimIndent(),
+                ),
+                javaClass(
+                    "com.example",
+                    "Person",
+                    """
+                        public String name;
+                        public Address address;
+                    """.trimIndent(),
+                ),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val personNode = graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<ObjectNode>()
+        personNode.properties.map { it.name }.shouldContainExactlyInAnyOrder(setOf("name", "address"))
+
+        personNode.properties.first { it.name == "address" }.type.shouldBeInstanceOf<TypeRef.Ref> { ref ->
+            ref.id.value shouldBe "com.example.Address"
+            ref.nullable shouldBe false
+        }
+
+        graph.nodes.getValue(TypeId("com.example.Address")).shouldBeInstanceOf<ObjectNode> { addressNode ->
+            addressNode.properties.map { it.name }.shouldContainExactlyInAnyOrder(setOf("city", "street"))
+        }
+    }
+
+    @Test
+    fun `introspects java lang Object field as inline AnyNode`() {
+        val graph =
+            graph(
+                root = "com.example.Wrapper",
+                javaClass("com.example", "Wrapper", "public Object payload;"),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<AnyNode>()
+            inline.nullable shouldBe false
+        }
+
+        // java.lang.Object must not create a named node in the graph
+        graph.nodes.keys.none { it.value == "java.lang.Object" } shouldBe true
+    }
+
+    @Test
+    fun `introspects list set and collection fields as inline list nodes`() {
+        val graph =
+            graph(
+                root = "com.example.Bundle",
+                javaClass(
+                    "com.example",
+                    "Bundle",
+                    """
+                        public java.util.List<String> names;
+                        public java.util.Set<Integer> scores;
+                        public java.util.Collection<Double> ratios;
+                    """.trimIndent(),
+                ),
+            )
+
+        val props = graph.rootNode().properties.associateBy { it.name }
+
+        props.getValue("names").type.shouldBeList { element ->
+            element.shouldBePrimitive(PrimitiveKind.STRING)
+        }
+        props.getValue("scores").type.shouldBeList { element ->
+            element.shouldBePrimitive(PrimitiveKind.INT)
+        }
+        props.getValue("ratios").type.shouldBeList { element ->
+            element.shouldBePrimitive(PrimitiveKind.DOUBLE)
+        }
+    }
+
+    @Test
+    fun `introspects map field as inline map node with key and value types`() {
+        val graph =
+            graph(
+                root = "com.example.Attributes",
+                javaClass(
+                    "com.example",
+                    "Attributes",
+                    "public java.util.Map<String, Integer> attributes;",
+                ),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeMap(
+            key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
+            value = { it.shouldBePrimitive(PrimitiveKind.INT) },
+        )
+    }
+
+    @Test
+    fun `introspects array fields as inline list nodes with component type`() {
+        val graph =
+            graph(
+                root = "com.example.ArraysHolder",
+                javaClass(
+                    "com.example",
+                    "ArraysHolder",
+                    """
+                        public String[] names;
+                        public int[] counts;
+                        public Integer[] boxed;
+                        public double[][] matrix;
+                    """.trimIndent(),
+                ),
+            )
+
+        val props = graph.rootNode().properties.associateBy { it.name }
+
+        props.getValue("names").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
+        props.getValue("counts").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
+        props.getValue("boxed").type.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) }
+        props.getValue("matrix").type.shouldBeList { nested ->
+            nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.DOUBLE) }
+        }
+    }
+
+    @Test
+    fun `introspects nested collections`() {
+        val graph =
+            graph(
+                root = "com.example.Nested",
+                javaClass(
+                    "com.example",
+                    "Nested",
+                    """
+                        public java.util.List<java.util.List<String>> matrix;
+                        public java.util.Map<String, java.util.List<Integer>> grouped;
+                        public java.util.List<java.util.Map<String, java.lang.Boolean>> flags;
+                    """.trimIndent(),
+                ),
+            )
+
+        val props = graph.rootNode().properties.associateBy { it.name }
+
+        props.getValue("matrix").type.shouldBeList { nested ->
+            nested.shouldBeList { it.shouldBePrimitive(PrimitiveKind.STRING) }
+        }
+        props.getValue("grouped").type.shouldBeMap(
+            key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
+            value = { value -> value.shouldBeList { it.shouldBePrimitive(PrimitiveKind.INT) } },
+        )
+        props.getValue("flags").type.shouldBeList { element ->
+            element.shouldBeMap(
+                key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
+                value = { it.shouldBePrimitive(PrimitiveKind.BOOLEAN) },
+            )
+        }
+    }
+
+    @Test
+    fun `introspects list of nested objects with ref element`() {
+        val graph =
+            graph(
+                root = "com.example.Catalog",
+                javaClass("com.example", "Address", "public String city;"),
+                javaClass("com.example", "Catalog", "public java.util.List<Address> addresses;"),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeList { element ->
+            element.shouldBeInstanceOf<TypeRef.Ref> { ref ->
+                ref.id.value shouldBe "com.example.Address"
+            }
+        }
+
+        graph.nodes.keys.any { it.value == "com.example.Address" } shouldBe true
+    }
+
+    @Test
+    fun `introspects record components as object node properties`() {
+        val graph =
+            graph(
+                root = "com.example.Person",
+                javaRecord("com.example", "Person(String name, int age)"),
+            )
+
+        val node = graph.rootNode()
+        node.required.shouldContainExactlyInAnyOrder(setOf("name", "age"))
+        val props = node.properties.associateBy { it.name }
+        props.getValue("name").type.shouldBePrimitive(PrimitiveKind.STRING)
+        props.getValue("age").type.shouldBePrimitive(PrimitiveKind.INT)
+    }
+
+    @Test
+    fun `introspects upper bounded type variable via its bound`() {
+        val graph =
+            graph(
+                root = "com.example.Box",
+                javaRecord("com.example", "Box<T extends Number>(T value)"),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeInstanceOf<TypeRef.Ref> { ref ->
+            ref.id.value shouldBe "java.lang.Number"
+        }
+
+        graph.nodes.keys.any { it.value == "java.lang.Number" } shouldBe true
+    }
+
+    @Test
+    fun `introspects unbounded type variable as inline AnyNode`() {
+        val graph =
+            graph(
+                root = "com.example.Box",
+                javaRecord("com.example", "Box<T>(T value)"),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<AnyNode>()
+        }
+    }
+
+    //endregion
+
+    //region helpers
+
+    private fun graph(
+        root: String,
+        vararg sources: String,
+    ): TypeGraph {
+        val fixture = introspectionFixture(root, *sources)
+        return AptClassIntrospector(fixture.processingEnv).introspect(fixture.typeElement)
+    }
+
+    private fun javaClass(
+        packageName: String,
+        className: String,
+        members: String,
+    ): String = """
+        package $packageName;
+
+        public class $className {
+        $members
+        }
+    """.trimIndent()
+
+    private fun javaRecord(
+        packageName: String,
+        declaration: String,
+    ): String = """
+        package $packageName;
+
+        public record $declaration {}
+    """.trimIndent()
+
+    private fun TypeGraph.rootNode(): ObjectNode =
+        root.shouldBeInstanceOf<TypeRef.Ref>()
+            .let { nodes.getValue(it.id) }
+            .shouldBeInstanceOf<ObjectNode>()
+
+    private fun TypeRef.shouldBePrimitive(kind: PrimitiveKind) {
+        shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                prim.kind shouldBe kind
+            }
+        }
+    }
+
+    private fun TypeRef.shouldBeList(element: (TypeRef) -> Unit) {
+        shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<ListNode> { list ->
+                element(list.element)
+            }
+        }
+    }
+
+    private fun TypeRef.shouldBeMap(
+        key: (TypeRef) -> Unit,
+        value: (TypeRef) -> Unit,
+    ) {
+        shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<MapNode> { map ->
+                key(map.key)
+                value(map.value)
+            }
+        }
+    }
+
+    private data class IntrospectionFixture(
+        val typeElement: TypeElement,
+        val processingEnv: ProcessingEnvironment,
+    )
+
+    private fun introspectionFixture(
+        root: String,
+        vararg sources: String,
+    ): IntrospectionFixture {
+        val compiler = ToolProvider.getSystemJavaCompiler()
+            ?: error("No system Java compiler available — run on JDK, not JRE")
+
+        val rootDir = Files.createTempDirectory("kt-schema-apt-test")
+        val outputDir = rootDir.resolve("classes").also { Files.createDirectories(it) }
+        try {
+            val diagnostics = DiagnosticCollector<JavaFileObject>()
+
+            val sourceFiles = sources.map { code ->
+                val pkg = Regex("""package\s+(\S+);""").find(code)?.groupValues?.get(1) ?: ""
+                val cls =
+                    Regex("""(?:public\s+)?(?:record|class|interface|enum)\s+(\w+)""").find(code)?.groupValues?.get(1)
+                        ?: error("Cannot infer class name from source:\n$code")
+                val fqn = "$pkg.$cls"
+                object : SimpleJavaFileObject(
+                    URI.create("string:///${fqn.replace('.', '/')}${JavaFileObject.Kind.SOURCE.extension}"),
+                    JavaFileObject.Kind.SOURCE,
+                ) {
+                    override fun getCharContent(ignoreEncodingErrors: Boolean) = code
+                }
+            }
+
+            val processor =
+                object : AbstractProcessor() {
+                    var captured: IntrospectionFixture? = null
+
+                    override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
+
+                    override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf("*")
+
+                    override fun process(
+                        annotations: MutableSet<out TypeElement>,
+                        roundEnv: RoundEnvironment,
+                    ): Boolean {
+                        if (captured == null) {
+                            val element =
+                                roundEnv.rootElements
+                                    .filterIsInstance<TypeElement>()
+                                    .firstOrNull { it.qualifiedName.contentEquals(root) }
+                            if (element != null) {
+                                captured = IntrospectionFixture(element, processingEnv)
+                            }
+                        }
+                        return false
+                    }
+                }
+
+            val writer = StringWriter()
+            val task =
+                compiler.getTask(
+                    writer,
+                    null,
+                    diagnostics,
+                    listOf("-d", outputDir.toFile().absolutePath),
+                    null,
+                    sourceFiles,
+                )
+            task.setProcessors(listOf(processor))
+
+            val success = task.call()
+            if (!success) {
+                val messages = diagnostics.diagnostics.joinToString("\n") { it.toString() }
+                error("Compilation failed:\n$messages\nCompiler output:\n$writer")
+            }
+
+            return processor.captured ?: error("Type $root not found in compilation")
+        } finally {
+            rootDir.toFile().deleteRecursively()
+        }
+    }
+
+    //endregion
+}


### PR DESCRIPTION
## Description

#74 Extend AptClassIntrospector to convert Java collections (List/Set/Collection), maps, arrays and upper-bounded type variables into IR list/map nodes, matching the reflection introspector's behavior. Container-kind detection is memoized per type, and Object maps to AnyNode.

Add comprehensive IR-level tests covering fields, primitives, nested objects, lists, maps, arrays, nested collections and a JSON round-trip test.


## Summary

- **New Features**
  - Expanded JSON Schema generation to support arrays, collections, maps, nested generics, wildcard bounds, and upper-bounded type variables.
  - Arrays and collections are represented as lists, while maps include typed additional properties.
  - Added safer fallbacks for raw or unbounded map types.
  - Improved handling of nested objects and reusable schema references.
- **Tests**
  - Added comprehensive coverage for scalar types, collections, maps, arrays, records, nested objects, references, and type variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Walkthrough

The annotation processor now passes `ProcessingEnvironment` to `AptClassIntrospector`. Type introspection now supports arrays, iterables, maps, wildcard bounds, upper-bounded type variables, and `Object`. These types map to list, map, any, or resolved reference nodes. Reference registration traverses nested container nodes. New tests cover Java type fixtures and generated schemas.

Issue: #74

---

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [x] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
