### PR TITLE
feat(apt): scope discovery by rootPackage and add include/exclude globs (#74)

### DIFF
--- a/apt-integration-tests/build.gradle.kts
+++ b/apt-integration-tests/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     annotationProcessor(project(":kt-schema-apt"))
 
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.assertj.core)
     testImplementation(libs.jackson.databind)
     testImplementation(platform(libs.junit.bom))
@@ -25,7 +26,10 @@ tasks.test {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add(
-        "-Ame.kpavlov.kt.schema.rootPackage=me.kpavlov.kt.schema.apt.integration"
+    options.compilerArgs.addAll(
+        listOf(
+            "-Ame.kpavlov.kt.schema.rootPackage=me.kpavlov.kt.schema.apt.integration",
+            "-Ame.kpavlov.kt.schema.include=me.kpavlov.kt.schema.apt.integration.**",
+        ),
     )
 }

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Address.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Address.java
@@ -1,0 +1,11 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Simple test model to verify nested object references in generated schemas.
+ */
+public record Address(
+        @JsonPropertyDescription("City or town name") String city,
+        @JsonPropertyDescription("Street name and number") String street) {
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Catalog.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Catalog.java
@@ -1,0 +1,17 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple test model to verify collection and map references to nested objects
+ * in generated schemas.
+ */
+@JsonClassDescription("A catalog of addresses.")
+public record Catalog(
+        @JsonPropertyDescription("Addresses in the catalog") List<Address> addresses,
+        @JsonPropertyDescription("Addresses grouped by city") Map<String, Address> byCity) {
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 /**
  * Simple test model to verify plain (non-record) Java class schema generation.
  */
-@SuppressWarnings("unused")
 @JsonClassDescription("A company with a name and a founding year.")
 public class Company {
 

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/AddressSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/AddressSchemaTest.java
@@ -10,13 +10,13 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies the kt-schema-apt processor generates a JSON Schema resource for a plain
- * (non-record) Java class selected by the configured {@code rootPackage} compiler option.
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * record used as a nested object reference by other types.
  */
-class ClassSchemaTest {
+class AddressSchemaTest {
 
     private static final String RESOURCE_PATH =
-            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Company.json";
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Address.json";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -27,22 +27,21 @@ class ClassSchemaTest {
         // language=json
         JsonNode expected = MAPPER.readTree("""
                 {
-                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Company",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Address",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "name": {
+                    "city": {
                       "type": "string",
-                      "description": "Name of the company"
+                      "description": "City or town name"
                     },
-                    "founded": {
-                      "type": "integer",
-                      "description": "Year the company was founded"
+                    "street": {
+                      "type": "string",
+                      "description": "Street name and number"
                     }
                   },
-                  "required": ["name", "founded"],
                   "additionalProperties": false,
-                  "description": "A company with a name and a founding year."
+                  "required": ["city", "street"]
                 }
                 """);
 

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CatalogSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CatalogSchemaTest.java
@@ -1,0 +1,81 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * record referencing a nested object via a list and a map.
+ */
+class CatalogSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Catalog.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldGenerateCompleteSchemaWithNestedRefs() throws IOException {
+        JsonNode actual = readGeneratedSchema();
+
+        // language=json
+        JsonNode expected = MAPPER.readTree("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Catalog",
+                  "description": "A catalog of addresses.",
+                  "type": "object",
+                  "properties": {
+                    "addresses": {
+                      "type": "array",
+                      "description": "Addresses in the catalog",
+                      "items": {
+                        "$ref": "#/$defs/me.kpavlov.kt.schema.apt.integration.type.Address"
+                      }
+                    },
+                    "byCity": {
+                      "type": "object",
+                      "description": "Addresses grouped by city",
+                      "additionalProperties": {
+                        "$ref": "#/$defs/me.kpavlov.kt.schema.apt.integration.type.Address"
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["addresses", "byCity"],
+                  "$defs": {
+                    "me.kpavlov.kt.schema.apt.integration.type.Address": {
+                      "type": "object",
+                      "properties": {
+                        "city": {
+                          "type": "string",
+                          "description": "City or town name"
+                        },
+                        "street": {
+                          "type": "string",
+                          "description": "Street name and number"
+                        }
+                      },
+                      "required": ["city", "street"],
+                      "additionalProperties": false
+                    }
+                  }
+                }
+                """);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private JsonNode readGeneratedSchema() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            assertThat(input).as("generated schema resource: %s", RESOURCE_PATH).isNotNull();
+            return MAPPER.readTree(input);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
@@ -10,14 +10,13 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java record
- * selected by the configured {@code rootPackage} compiler option, not because it is
- * annotated with {@code @Schema}.
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a plain
+ * (non-record) Java class selected by the configured {@code rootPackage} compiler option.
  */
-class RecordSchemaTest {
+class CompanySchemaTest {
 
     private static final String RESOURCE_PATH =
-            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Company.json";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -28,26 +27,22 @@ class RecordSchemaTest {
         // language=json
         JsonNode expected = MAPPER.readTree("""
                 {
-                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Company",
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "firstName": {
+                    "name": {
                       "type": "string",
-                      "description": "Given name of the person"
+                      "description": "Name of the company"
                     },
-                    "lastName": {
-                      "type": "string",
-                      "description": "Family name of the person"
-                    },
-                    "age": {
+                    "founded": {
                       "type": "integer",
-                      "description": "Age of the person in years"
+                      "description": "Year the company was founded"
                     }
                   },
-                  "required": ["firstName", "lastName", "age"],
+                  "required": ["name", "founded"],
                   "additionalProperties": false,
-                  "description": "A person with a first and last name and age."
+                  "description": "A company with a name and a founding year."
                 }
                 """);
 

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
@@ -1,0 +1,62 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * record selected by the configured {@code rootPackage} compiler option.
+ */
+class PersonSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Person.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldGenerateCompleteSchemaWithAllRequiredFields() throws IOException {
+        JsonNode actual = readGeneratedSchema();
+
+        // language=json
+        JsonNode expected = MAPPER.readTree("""
+                {
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Person",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "firstName": {
+                      "type": "string",
+                      "description": "Given name of the person"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "description": "Family name of the person"
+                    },
+                    "age": {
+                      "type": "integer",
+                      "description": "Age of the person in years"
+                    }
+                  },
+                  "required": ["firstName", "lastName", "age"],
+                  "additionalProperties": false,
+                  "description": "A person with a first and last name and age."
+                }
+                """);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private JsonNode readGeneratedSchema() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            assertThat(input).as("generated schema resource: %s", RESOURCE_PATH).isNotNull();
+            return MAPPER.readTree(input);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/ProductSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/ProductSchemaTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
  * interface selected by the configured {@code rootPackage} compiler option.
  */
-class InterfaceSchemaTest {
+class ProductSchemaTest {
 
     private static final String RESOURCE_PATH =
             "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Product.json";

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -37,6 +37,7 @@ Generate JSON Schema resources at compile time from plain Java records, classes 
         </annotationProcessorPaths>
         <compilerArgs>
             <arg>-Ame.kpavlov.kt.schema.rootPackage=com.example</arg>
+            <arg>-Ame.kpavlov.kt.schema.include=com.example.**</arg>
         </compilerArgs>
     </configuration>
 </plugin>
@@ -67,11 +68,16 @@ dependencies {
 
 ## Triggering schema generation
 
-The processor picks up a Java type either of two ways — you don't need both:
+The processor discovers types as follows:
 
-1. **Annotate the type with `@Schema`** (from `kt-schema-annotations`) — processed regardless of package.
-2. **Set the [`rootPackage`](#configuration-options) option** — every top-level `record`, `class` or `interface`
-   declared under that package (and its sub-packages) is processed, `@Schema` or not.
+1. **Scope** — when the [`rootPackage`](#configuration-options) option is set, only types
+   declared under that package (and its sub-packages) are considered; otherwise the whole
+   module is scanned. This applies to `@Schema`-annotated types and include-glob matches alike.
+2. **Selection** — a `record`, `class` or `interface` is processed when it is annotated with
+   `@Schema` (from `kt-schema-annotations`) or matches at least one
+   [`include`](#configuration-options) glob pattern.
+3. **Exclusion** — a type matching any [`exclude`](#configuration-options) glob pattern is
+   dropped, even when selected by `@Schema` or an include pattern.
 
 ```java
 import me.kpavlov.kt.schema.Description;
@@ -86,8 +92,8 @@ public record Person(
 }
 ```
 
-With `rootPackage` configured, you can skip `kt-schema-annotations` entirely and reuse annotations you
-already depend on — for example Jackson's:
+With `rootPackage` + `include` configured, you can skip `kt-schema-annotations` entirely and reuse
+annotations you already depend on — for example Jackson's:
 
 ```java
 import com.fasterxml.jackson.annotation.JsonClassDescription;
@@ -108,20 +114,25 @@ public record Person(
 
 | Option        | Type     | Default | Description                                                                                                     |
 |:--------------|:---------|:--------|:------------------------------------------------------------------------------------------------------------------|
-| `rootPackage` | `String` | `null`  | Process every top-level `record`, `class` or `interface` under this package (and sub-packages), in addition to `@Schema`-annotated types.   |
+| `rootPackage` | `String` | `null`  | Scope discovery to types declared under this package (and sub-packages); absent means the whole module is scanned.  |
+| `include`     | `String` | `null`  | Comma/semicolon-separated glob patterns; a type not annotated with `@Schema` is processed only when it matches at least one. |
+| `exclude`     | `String` | `null`  | Comma/semicolon-separated glob patterns; a type matching any of them is dropped, even when `@Schema`-annotated or include-matched. |
 
-Set it as a javac `-A` compiler argument:
+Set them as javac `-A` compiler arguments:
 
 ```kotlin
 tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Ame.kpavlov.kt.schema.rootPackage=com.example")
+    options.compilerArgs.addAll(
+        listOf(
+            "-Ame.kpavlov.kt.schema.rootPackage=com.example",
+            "-Ame.kpavlov.kt.schema.include=com.example.**",
+        ),
+    )
 }
 ```
 
-> [!NOTE]
-> `kt-schema-apt` is newer than the KSP processor and doesn't yet support all of its options.
-> `include`/`exclude` glob filtering, `withSchemaObject`, `visibility`, and `enabled` from
-> [the KSP processor](ksp.md) aren't implemented here yet.
+Glob syntax: `*` matches any sequence of non-`.` characters, `**` matches any sequence including
+`.`, `?` matches a single non-`.` character — the same syntax the KSP processor uses.
 
 ## Generated output
 

--- a/kt-schema-apt/api/kt-schema-apt.api
+++ b/kt-schema-apt/api/kt-schema-apt.api
@@ -1,5 +1,7 @@
 public final class me/kpavlov/kt/schema/apt/JsonSchemaProcessor : javax/annotation/processing/AbstractProcessor {
 	public static final field Companion Lme/kpavlov/kt/schema/apt/JsonSchemaProcessor$Companion;
+	public static final field EXCLUDE_OPTION Ljava/lang/String;
+	public static final field INCLUDE_OPTION Ljava/lang/String;
 	public static final field ROOT_PACKAGE_OPTION Ljava/lang/String;
 	public fun <init> ()V
 	public fun getSupportedSourceVersion ()Ljavax/lang/model/SourceVersion;

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -4,6 +4,8 @@ package me.kpavlov.kt.schema.apt
 import kotlinx.serialization.json.Json
 import me.kpavlov.kt.schema.Schema
 import me.kpavlov.kt.schema.apt.ir.AptClassIntrospector
+import me.kpavlov.kt.schema.generator.core.GlobMatcher
+import me.kpavlov.kt.schema.generator.core.parseGlobPatterns
 import me.kpavlov.kt.schema.generator.json.JsonSchemaConfig
 import me.kpavlov.kt.schema.generator.json.TypeGraphToJsonSchemaTransformer
 import me.kpavlov.kt.schema.json.JsonSchema
@@ -26,8 +28,8 @@ import javax.tools.StandardLocation
  * processor uses, so output shape ($id/$defs/$ref/nullability) stays identical.
  *
  * Supports `"*"` annotation types so javac invokes it in every round: this lets the
- * [ROOT_PACKAGE_OPTION] scanning pick up types even when no `@Schema` annotation is
- * present in the compilation. The processor never claims annotations (always returns
+ * [ROOT_PACKAGE_OPTION]/[INCLUDE_OPTION] scanning pick up types even when no `@Schema`
+ * annotation is present in the compilation. The processor never claims annotations (always returns
  * `false`) and deduplicates by type name, so it coexists safely with other processors.
  *
  * @author Konstantin Pavlov
@@ -35,6 +37,8 @@ import javax.tools.StandardLocation
 @SupportedAnnotationTypes("*")
 @SupportedOptions(
     JsonSchemaProcessor.ROOT_PACKAGE_OPTION,
+    JsonSchemaProcessor.INCLUDE_OPTION,
+    JsonSchemaProcessor.EXCLUDE_OPTION,
 )
 public class JsonSchemaProcessor : AbstractProcessor() {
     //region Processor state
@@ -89,25 +93,33 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     }
 
     /**
-     * Types annotated with `@Schema`, plus — when [ROOT_PACKAGE_OPTION] is configured —
-     * every record, class or interface declared under that package, so consumers don't
-     * have to annotate every type individually.
+     * Discovers the types to process, mirroring the KSP processor's filtering:
+     *
+     * 1. Only records, classes and interfaces are considered.
+     * 2. When [ROOT_PACKAGE_OPTION] is set, only types under that package (and its
+     *    sub-packages) are considered; otherwise the whole module is scanned.
+     * 3. A type is selected when it is annotated with `@Schema` or matches at least one
+     *    [INCLUDE_OPTION] glob pattern.
+     * 4. A type matching any [EXCLUDE_OPTION] glob pattern is dropped, even when selected
+     *    by `@Schema` or an include pattern.
      */
     private fun candidateTypes(roundEnv: RoundEnvironment): Set<TypeElement> {
+        val rootPackage = processingEnv.options[ROOT_PACKAGE_OPTION]?.trim()?.takeIf { it.isNotEmpty() }
+        val globMatcher =
+            GlobMatcher(
+                includePatterns = parseGlobPatterns(processingEnv.options[INCLUDE_OPTION]),
+                excludePatterns = parseGlobPatterns(processingEnv.options[EXCLUDE_OPTION]),
+            )
+
         val annotated = roundEnv.getElementsAnnotatedWith(Schema::class.java).filterIsInstance<TypeElement>()
+        val fromRoots = roundEnv.rootElements.filterIsInstance<TypeElement>()
 
-        val rootPackage = processingEnv.options[ROOT_PACKAGE_OPTION]
-        val underRootPackage =
-            if (rootPackage.isNullOrBlank()) {
-                emptyList()
-            } else {
-                roundEnv.rootElements
-                    .filterIsInstance<TypeElement>()
-                    .filter { it.isSupported() }
-                    .filter { it.isUnderPackage(rootPackage) }
-            }
-
-        return (annotated + underRootPackage).toSet()
+        return (annotated + fromRoots)
+            .filter { it.isSupported() }
+            .filter { rootPackage == null || it.isUnderPackage(rootPackage) }
+            .filter { it.isAnnotatedWithSchema() || globMatcher.matchesInclude(it.qualifiedName.toString()) }
+            .filterNot { globMatcher.matchesExclude(it.qualifiedName.toString()) }
+            .toSet()
     }
 
     private fun TypeElement.isSupported(): Boolean =
@@ -117,6 +129,12 @@ public class JsonSchemaProcessor : AbstractProcessor() {
         val packageName = processingEnv.elementUtils.getPackageOf(this).qualifiedName.toString()
         return packageName == rootPackage || packageName.startsWith("$rootPackage.")
     }
+
+    private fun TypeElement.isAnnotatedWithSchema(): Boolean =
+        annotationMirrors.any { mirror ->
+            (mirror.annotationType.asElement() as? TypeElement)?.qualifiedName?.toString() ==
+                Schema::class.qualifiedName
+        }
 
     //endregion
 
@@ -168,12 +186,26 @@ public class JsonSchemaProcessor : AbstractProcessor() {
 
     public companion object {
         /**
-         * Processor option (`-A<name>=<value>`) that, when set, processes every top-level
-         * record, class or interface declared under the given package (and its sub-packages)
-         * in addition to types annotated with `@Schema`. Lets consumers skip annotating
-         * every type individually.
+         * Processor option (`-A<name>=<value>`) that, when set, restricts discovery to types
+         * declared under the given package (and its sub-packages). When absent, the whole
+         * module is scanned. Applies to `@Schema`-annotated types and include-glob matches alike.
          */
         public const val ROOT_PACKAGE_OPTION: String = "me.kpavlov.kt.schema.rootPackage"
+
+        /**
+         * Processor option (`-A<name>=<value>`) with comma/semicolon-separated glob patterns.
+         * A type not annotated with `@Schema` is processed only when it matches at least one
+         * include pattern. Glob syntax: `*` matches any sequence of non-`.` characters,
+         * `**` any sequence including `.`, `?` a single non-`.` character.
+         */
+        public const val INCLUDE_OPTION: String = "me.kpavlov.kt.schema.include"
+
+        /**
+         * Processor option (`-A<name>=<value>`) with comma/semicolon-separated glob patterns.
+         * A type matching any exclude pattern is dropped, even when it is `@Schema`-annotated
+         * or matches an include pattern. Glob syntax matches [INCLUDE_OPTION].
+         */
+        public const val EXCLUDE_OPTION: String = "me.kpavlov.kt.schema.exclude"
     }
 
     //endregion

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -1,17 +1,26 @@
 package me.kpavlov.kt.schema.apt
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
 import java.io.StringWriter
 import java.nio.file.Path
+import java.util.stream.Stream
 import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
 import javax.tools.ToolProvider
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JsonSchemaProcessorTest {
 
     //region test cases
@@ -30,10 +39,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Person") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Person",
@@ -48,8 +55,11 @@ class JsonSchemaProcessorTest {
         """.trimIndent()
     }
 
-    @Test
-    fun `should resolve record component description from record component annotation`(
+    @ParameterizedTest(name = "should resolve record component description from {0} annotation")
+    @MethodSource("descriptionTargets")
+    fun `should resolve record component description`(
+        targets: String,
+        expectedDescription: String,
         @TempDir tempDir: Path,
     ) {
         // language=java
@@ -61,7 +71,7 @@ class JsonSchemaProcessorTest {
             import java.lang.annotation.RetentionPolicy;
             import java.lang.annotation.Target;
 
-            @Target(ElementType.RECORD_COMPONENT)
+            @Target($targets)
             @Retention(RetentionPolicy.RUNTIME)
             public @interface Description {
                 String value();
@@ -72,19 +82,20 @@ class JsonSchemaProcessorTest {
         val recordSource = """
             package com.example;
 
-            public record Foo(@Description("component description") String name) {}
+            public record Foo(@Description("$expectedDescription") String name) {}
         """.trimIndent()
 
         val outputDir = compile(
             sources = listOf(annotationSource, recordSource),
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
         )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Foo") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Foo",
@@ -92,152 +103,11 @@ class JsonSchemaProcessorTest {
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "component description"
+                        "description": "$$expectedDescription"
                     }
                 },
                 "additionalProperties": false,
                 "required": ["name"]
-            }
-        """.trimIndent()
-    }
-
-    @Test
-    fun `should resolve record component description from accessor annotation`(
-        @TempDir tempDir: Path,
-    ) {
-        // language=java
-        val annotationSource = """
-            package com.example;
-
-            import java.lang.annotation.ElementType;
-            import java.lang.annotation.Retention;
-            import java.lang.annotation.RetentionPolicy;
-            import java.lang.annotation.Target;
-
-            @Target(ElementType.METHOD)
-            @Retention(RetentionPolicy.RUNTIME)
-            public @interface Description {
-                String value();
-            }
-        """.trimIndent()
-
-        val recordSource = """
-            package com.example;
-
-            public record Foo(@Description("accessor description") String name) {}
-        """.trimIndent()
-
-        val outputDir = compile(
-            sources = listOf(annotationSource, recordSource),
-            tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
-        )
-
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
-        schemaFile.toFile().exists() shouldBe true
-        // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
-            {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "$id": "com.example.Foo",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "accessor description"
-                    }
-                },
-                "additionalProperties": false,
-                "required": ["name"]
-            }
-        """.trimIndent()
-    }
-
-    @Test
-    fun `should resolve record component description from backing field annotation`(
-        @TempDir tempDir: Path,
-    ) {
-        // language=java
-        val annotationSource = """
-            package com.example;
-
-            import java.lang.annotation.ElementType;
-            import java.lang.annotation.Retention;
-            import java.lang.annotation.RetentionPolicy;
-            import java.lang.annotation.Target;
-
-            @Target(ElementType.FIELD)
-            @Retention(RetentionPolicy.RUNTIME)
-            public @interface Description {
-                String value();
-            }
-        """.trimIndent()
-
-        val recordSource = """
-            package com.example;
-
-            public record Foo(@Description("field description") String name) {}
-        """.trimIndent()
-
-        val outputDir = compile(
-            sources = listOf(annotationSource, recordSource),
-            tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
-        )
-
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
-        schemaFile.toFile().exists() shouldBe true
-        // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
-            {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "$id": "com.example.Foo",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "field description"
-                    }
-                },
-                "additionalProperties": false,
-                "required": ["name"]
-            }
-        """.trimIndent()
-    }
-
-    @Test
-    fun `should generate schema for record via root package option`(
-        @TempDir tempDir: Path,
-    ) {
-        // language=java
-        val source = """
-            package com.example;
-
-            import me.kpavlov.kt.schema.Schema;
-
-            @Schema
-            public record Foo(String value) {}
-        """.trimIndent()
-
-        val outputDir = compile(
-            source = source,
-            tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
-        )
-
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Foo.json")
-        schemaFile.toFile().exists() shouldBe true
-        // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
-            {
-                "$schema": "https://json-schema.org/draft/2020-12/schema",
-                "$id": "com.example.Foo",
-                "type": "object",
-                "properties": {
-                    "value": { "type": "string" }
-                },
-                "additionalProperties": false,
-                "required": ["value"]
             }
         """.trimIndent()
     }
@@ -256,13 +126,14 @@ class JsonSchemaProcessorTest {
         val outputDir = compile(
             source = source,
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
         )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Person") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Person",
@@ -275,6 +146,118 @@ class JsonSchemaProcessorTest {
                 "required": ["name", "age"]
             }
         """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for unannotated record via include glob without root package`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            public record Person(String name, int age) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf("-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*"),
+        )
+
+        // language=json
+        outputDir.readSchema("com.example.Person") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Person",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "integer" }
+                },
+                "additionalProperties": false,
+                "required": ["name", "age"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema via include glob and drop only excluded types without root package`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val personSource = """
+            package com.example;
+
+            public record Person(String name) {}
+        """.trimIndent()
+
+        // language=java
+        val addressSource = """
+            package com.example;
+
+            public record Address(String city) {}
+        """.trimIndent()
+
+        val outputDir = compile(
+            sources = listOf(personSource, addressSource),
+            tempDir = tempDir,
+            options = listOf(
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.**",
+                "-A${JsonSchemaProcessor.EXCLUDE_OPTION}=**.Person",
+            ),
+        )
+
+        outputDir.hasSchema("com.example.Address") shouldBe true
+        outputDir.hasSchema("com.example.Person") shouldBe false
+    }
+
+    @ParameterizedTest(name = "should not generate schema when {0}")
+    @MethodSource("noSchemaCases")
+    @Suppress("UnusedParameter")
+    fun `should not generate schema`(
+        scenario: String,
+        source: String,
+        options: List<String>,
+        @TempDir tempDir: Path,
+    ) {
+        val outputDir = compile(source, tempDir, options)
+
+        outputDir.schemaFiles() shouldBe emptyList()
+    }
+
+    @Test
+    fun `should fail the build when a schema references an unsupported type`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val colorSource = """
+            package com.example;
+
+            public enum Color {
+                RED, GREEN, BLUE
+            }
+        """.trimIndent()
+
+        // language=java
+        val carSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Car(Color color) {}
+        """.trimIndent()
+
+        val exception =
+            assertFailsWith<IllegalStateException> {
+                compile(listOf(colorSource, carSource), tempDir)
+            }
+
+        assertSoftly(exception) {
+            message shouldContain "Unsupported type for kt-schema-apt"
+            message shouldContain "com.example.Color"
+        }
     }
 
     @Test
@@ -303,14 +286,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(listOf(addressSource, personSource), tempDir)
 
-        val personSchema =
-            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json").toFile()
-        val addressSchema =
-            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Address.json").toFile()
-
-        personSchema.exists() shouldBe true
         // language=json
-        personSchema.readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Person") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Person",
@@ -338,9 +315,8 @@ class JsonSchemaProcessorTest {
             }
         """.trimIndent()
 
-        addressSchema.exists() shouldBe true
         // language=json
-        addressSchema.readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Address") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Address",
@@ -396,11 +372,6 @@ class JsonSchemaProcessorTest {
         val outputDir =
             compile(listOf(vendorSource, lineItemSource, orderSource, invoiceSource), tempDir)
 
-        val orderSchema =
-            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json").toFile()
-        val invoiceSchema =
-            outputDir.resolve("META-INF/kt-schema/schemas/com/example/Invoice.json").toFile()
-
         // language=json
         val expectedSchema = $$"""
             {
@@ -440,14 +411,46 @@ class JsonSchemaProcessorTest {
             }
         """.trimIndent()
 
-        orderSchema.exists() shouldBe true
-        orderSchema.readText() shouldEqualJson expectedSchema
+        outputDir.readSchema("com.example.Order") shouldEqualJson expectedSchema
 
-        invoiceSchema.exists() shouldBe true
-        invoiceSchema.readText() shouldEqualJson expectedSchema.replace(
-            "\"\$id\": \"com.example.Order\"",
-            "\"\$id\": \"com.example.Invoice\"",
-        )
+        // language=json
+        outputDir.readSchema("com.example.Invoice") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Invoice",
+                "type": "object",
+                "properties": {
+                    "item": {
+                        "$ref": "#/$defs/com.example.LineItem"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["item"],
+                "$defs": {
+                    "com.example.LineItem": {
+                        "type": "object",
+                        "properties": {
+                            "sku": { "type": "string" },
+                            "quantity": { "type": "integer" },
+                            "vendor": {
+                                "$ref": "#/$defs/com.example.Vendor"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["sku", "quantity", "vendor"]
+                    },
+                    "com.example.Vendor": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "location": { "type": "string" }
+                        },
+                        "additionalProperties": false,
+                        "required": ["name", "location"]
+                    }
+                }
+            }
+        """.trimIndent()
     }
 
     @Test
@@ -475,13 +478,14 @@ class JsonSchemaProcessorTest {
             compile(
                 sources = listOf(addressSource, orderSource),
                 tempDir = tempDir,
-                options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+                options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
             )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Order") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Order",
@@ -546,10 +550,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Bundle.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Bundle") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Bundle",
@@ -590,10 +592,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/ArraysHolder.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.ArraysHolder") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.ArraysHolder",
@@ -635,10 +635,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Nested.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Nested") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Nested",
@@ -694,10 +692,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Wrapper.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Wrapper") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Wrapper",
@@ -727,10 +723,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Box.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Box") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Box",
@@ -770,10 +764,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Box.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Box") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Box",
@@ -810,10 +802,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(listOf(namesSource, orderSource), tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Order.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Order") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Order",
@@ -832,22 +822,63 @@ class JsonSchemaProcessorTest {
         """.trimIndent()
     }
 
-    @Test
-    fun `should not generate schema when no annotated types`(
+    @ParameterizedTest(name = "should generate schema for record with {0} of object components")
+    @MethodSource("objectCollectionFields")
+    @Suppress("UnusedParameter")
+    fun `should generate schema for record with collection of object components`(
+        kind: String,
+        fieldDeclaration: String,
+        requiredProperty: String,
+        propertySchema: String,
         @TempDir tempDir: Path,
     ) {
         // language=java
-        val source = """
+        val addressSource = """
             package com.example;
 
-            public record PlainRecord(String value) {}
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Address(String city) {}
         """.trimIndent()
 
-        val outputDir = compile(source, tempDir)
+        // language=java
+        val catalogSource = """
+            package com.example;
 
-        val schemaFiles =
-            outputDir.toFile().walkTopDown().filter { it.name.endsWith(".json") }.toList()
-        schemaFiles shouldBe emptyList()
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Catalog($fieldDeclaration) {}
+        """.trimIndent()
+
+        val outputDir = compile(listOf(addressSource, catalogSource), tempDir)
+
+        // language=json
+        outputDir.readSchema("com.example.Catalog") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Catalog",
+                "type": "object",
+                "properties": {
+                    $$propertySchema
+                },
+                "additionalProperties": false,
+                "required": ["$$requiredProperty"],
+                "$defs": {
+                    "com.example.Address": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["city"],
+                        "additionalProperties": false
+                    }
+                }
+            }
+        """.trimIndent()
     }
 
     @Test
@@ -872,13 +903,14 @@ class JsonSchemaProcessorTest {
         val outputDir = compile(
             source = source,
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
         )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Company.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Company") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Company",
@@ -916,10 +948,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Person.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Person") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Person",
@@ -960,13 +990,14 @@ class JsonSchemaProcessorTest {
         val outputDir = compile(
             source = source,
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
         )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Resource.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Resource") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Resource",
@@ -1001,13 +1032,14 @@ class JsonSchemaProcessorTest {
         val outputDir = compile(
             source = source,
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
         )
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Product.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Product") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Product",
@@ -1020,30 +1052,6 @@ class JsonSchemaProcessorTest {
                 "required": ["name", "price"]
             }
         """.trimIndent()
-    }
-
-    @Test
-    fun `should not generate schema for enum under root package`(
-        @TempDir tempDir: Path,
-    ) {
-        // language=java
-        val source = """
-            package com.example;
-
-            public enum Color {
-                RED, GREEN, BLUE
-            }
-        """.trimIndent()
-
-        val outputDir = compile(
-            source = source,
-            tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
-        )
-
-        val schemaFiles =
-            outputDir.toFile().walkTopDown().filter { it.name.endsWith(".json") }.toList()
-        schemaFiles shouldBe emptyList()
     }
 
     @Test
@@ -1060,14 +1068,14 @@ class JsonSchemaProcessorTest {
         val outputDir = compile(
             source = source,
             tempDir = tempDir,
-            options = listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.**",
+            ),
         )
 
-        val schemaFile =
-            outputDir.resolve("META-INF/kt-schema/schemas/com/example/sub/sub/DeepRecord.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.sub.sub.DeepRecord") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.sub.sub.DeepRecord",
@@ -1118,10 +1126,8 @@ class JsonSchemaProcessorTest {
 
         val outputDir = compile(source, tempDir)
 
-        val schemaFile = outputDir.resolve("META-INF/kt-schema/schemas/com/example/Scalars.json")
-        schemaFile.toFile().exists() shouldBe true
         // language=json
-        schemaFile.toFile().readText() shouldEqualJson $$"""
+        outputDir.readSchema("com.example.Scalars") shouldEqualJson $$"""
             {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "$id": "com.example.Scalars",
@@ -1134,6 +1140,158 @@ class JsonSchemaProcessorTest {
             }
         """.trimIndent()
     }
+
+    //endregion
+
+    //region test data
+
+    private fun descriptionTargets(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of("ElementType.RECORD_COMPONENT", "component description"),
+            Arguments.of("ElementType.METHOD", "accessor description"),
+            Arguments.of("ElementType.FIELD", "field description"),
+            Arguments.of(
+                "{ElementType.RECORD_COMPONENT, ElementType.METHOD, ElementType.FIELD}",
+                "component description",
+            ),
+        )
+
+    private fun noSchemaCases(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of(
+                "annotated record is outside root package",
+                annotatedRecordOutsideRootPackage,
+                listOf("-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example"),
+            ),
+            Arguments.of(
+                "exclude glob matches an annotated type",
+                annotatedPerson,
+                listOf("-A${JsonSchemaProcessor.EXCLUDE_OPTION}=com.example.*"),
+            ),
+            Arguments.of(
+                "exclude glob wins over include glob",
+                plainPerson,
+                listOf(
+                    "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.**",
+                    "-A${JsonSchemaProcessor.EXCLUDE_OPTION}=**.Person",
+                ),
+            ),
+            Arguments.of(
+                "type is an annotated enum",
+                annotatedEnum,
+                emptyList<String>(),
+            ),
+            Arguments.of(
+                "type is an enum under root package",
+                plainEnum,
+                listOf(
+                    "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                ),
+            ),
+            Arguments.of(
+                "no annotated or matching types are present",
+                plainRecord,
+                emptyList<String>(),
+            ),
+        )
+
+    // language=java
+    private val annotatedRecordOutsideRootPackage = """
+        package com.other;
+
+        import me.kpavlov.kt.schema.Schema;
+
+        @Schema
+        public record Person(String name, int age) {}
+    """.trimIndent()
+
+    // language=java
+    private val annotatedPerson = """
+        package com.example;
+
+        import me.kpavlov.kt.schema.Schema;
+
+        @Schema
+        public record Person(String name) {}
+    """.trimIndent()
+
+    // language=java
+    private val plainPerson = """
+        package com.example;
+
+        public record Person(String name) {}
+    """.trimIndent()
+
+    // language=java
+    private val annotatedEnum = """
+        package com.example;
+
+        import me.kpavlov.kt.schema.Schema;
+
+        @Schema
+        public enum Color {
+            RED, GREEN, BLUE
+        }
+    """.trimIndent()
+
+    // language=java
+    private val plainEnum = """
+        package com.example;
+
+        public enum Color {
+            RED, GREEN, BLUE
+        }
+    """.trimIndent()
+
+    // language=java
+    private val plainRecord = """
+        package com.example;
+
+        public record PlainRecord(String value) {}
+    """.trimIndent()
+
+    private fun objectCollectionFields(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of(
+                "list",
+                "java.util.List<Address> addresses",
+                "addresses",
+                $$"""
+                    "addresses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/com.example.Address"
+                        }
+                    }
+                """.trimIndent(),
+            ),
+            Arguments.of(
+                "set",
+                "java.util.Set<Address> addresses",
+                "addresses",
+                $$"""
+                    "addresses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/com.example.Address"
+                        }
+                    }
+                """.trimIndent(),
+            ),
+            Arguments.of(
+                "map",
+                "java.util.Map<String, Address> byCity",
+                "byCity",
+                $$"""
+                    "byCity": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/$defs/com.example.Address"
+                        }
+                    }
+                """.trimIndent(),
+            ),
+        )
 
     //endregion
 
@@ -1184,5 +1342,20 @@ class JsonSchemaProcessorTest {
 
         return outputDir
     }
+
+    private fun Path.readSchema(fqn: String): String {
+        val file = schemaFile(fqn)
+        file.exists() shouldBe true
+        return file.readText()
+    }
+
+    private fun Path.hasSchema(fqn: String): Boolean =
+        schemaFile(fqn).exists()
+
+    private fun Path.schemaFiles(): List<File> =
+        toFile().walkTopDown().filter { it.name.endsWith(".json") }.toList()
+
+    private fun Path.schemaFile(fqn: String): File =
+        resolve("META-INF/kt-schema/schemas/${fqn.replace('.', '/')}.json").toFile()
     //endregion
 }

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -15,10 +15,14 @@ import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
 import me.kpavlov.kt.schema.generator.core.ir.TypeId
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.StringWriter
 import java.nio.file.Files
+import java.util.stream.Stream
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
@@ -27,11 +31,12 @@ import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
 import javax.tools.ToolProvider
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AptClassIntrospectorTest {
     //region test cases
 
     @Test
-    fun `introspects plain class instance fields and excludes static fields`() {
+    fun `should introspect plain class instance fields and exclude static fields`() {
         val graph =
             graph(
                 root = "com.example.Company",
@@ -112,7 +117,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects nested object field as ref with object node registered in graph`() {
+    fun `should introspect nested object field as ref with object node registered in graph`() {
         val graph =
             graph(
                 root = "com.example.Person",
@@ -149,7 +154,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects java lang Object field as inline AnyNode`() {
+    fun `should introspect java lang Object field as inline AnyNode`() {
         val graph =
             graph(
                 root = "com.example.Wrapper",
@@ -166,7 +171,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects list set and collection fields as inline list nodes`() {
+    fun `should introspect list set and collection fields as inline list nodes`() {
         val graph =
             graph(
                 root = "com.example.Bundle",
@@ -197,7 +202,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects map field as inline map node with key and value types`() {
+    fun `should introspect map field as inline map node with key and value types`() {
         val graph =
             graph(
                 root = "com.example.Attributes",
@@ -215,7 +220,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects array fields as inline list nodes with component type`() {
+    fun `should introspect array fields as inline list nodes with component type`() {
         val graph =
             graph(
                 root = "com.example.ArraysHolder",
@@ -244,7 +249,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects nested collections`() {
+    fun `should introspect nested collections`() {
         val graph =
             graph(
                 root = "com.example.Nested",
@@ -278,26 +283,28 @@ class AptClassIntrospectorTest {
         }
     }
 
-    @Test
-    fun `introspects list of nested objects with ref element`() {
+    @ParameterizedTest(name = "should introspect {0} of nested objects with ref element")
+    @MethodSource("objectContainerFields")
+    fun `should introspect container of nested objects with ref element`(
+        @Suppress("UnusedParameter") kind: String,
+        fieldDeclaration: String,
+        assertFieldType: (TypeRef) -> Unit,
+    ) {
         val graph =
             graph(
                 root = "com.example.Catalog",
                 javaClass("com.example", "Address", "public String city;"),
-                javaClass("com.example", "Catalog", "public java.util.List<Address> addresses;"),
+                javaClass("com.example", "Catalog", "public $fieldDeclaration;"),
             )
 
-        graph.rootNode().properties.single().type.shouldBeList { element ->
-            element.shouldBeInstanceOf<TypeRef.Ref> { ref ->
-                ref.id.value shouldBe "com.example.Address"
-            }
-        }
+        val fieldType = graph.rootNode().properties.single().type
+        assertFieldType(fieldType)
 
         graph.nodes.keys.any { it.value == "com.example.Address" } shouldBe true
     }
 
     @Test
-    fun `introspects record components as object node properties`() {
+    fun `should introspect record components as object node properties`() {
         val graph =
             graph(
                 root = "com.example.Person",
@@ -314,7 +321,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects upper bounded type variable via its bound`() {
+    fun `should introspect upper bounded type variable via its bound`() {
         val graph =
             graph(
                 root = "com.example.Box",
@@ -329,7 +336,7 @@ class AptClassIntrospectorTest {
     }
 
     @Test
-    fun `introspects unbounded type variable as inline AnyNode`() {
+    fun `should introspect unbounded type variable as inline AnyNode`() {
         val graph =
             graph(
                 root = "com.example.Box",
@@ -344,6 +351,38 @@ class AptClassIntrospectorTest {
     //endregion
 
     //region helpers
+
+    private fun objectContainerFields(): Stream<Arguments> =
+        Stream.of(
+            Arguments.of(
+                "list",
+                "java.util.List<Address> addresses",
+                { field: TypeRef ->
+                    field.shouldBeList { element ->
+                        element.shouldBeRefTo("com.example.Address")
+                    }
+                },
+            ),
+            Arguments.of(
+                "collection",
+                "java.util.Collection<Address> addresses",
+                { field: TypeRef ->
+                    field.shouldBeList { element ->
+                        element.shouldBeRefTo("com.example.Address")
+                    }
+                },
+            ),
+            Arguments.of(
+                "map",
+                "java.util.Map<String, Address> byCity",
+                { field: TypeRef ->
+                    field.shouldBeMap(
+                        key = { it.shouldBePrimitive(PrimitiveKind.STRING) },
+                        value = { it.shouldBeRefTo("com.example.Address") },
+                    )
+                },
+            ),
+        )
 
     private fun graph(
         root: String,
@@ -463,6 +502,11 @@ class AptClassIntrospectorTest {
         }
     }
 
+    private fun TypeRef.shouldBeRefTo(fqn: String) {
+        shouldBeInstanceOf<TypeRef.Ref> { ref ->
+            ref.id.value shouldBe fqn
+        }
+    }
 
     //endregion
 }

--- a/kt-schema-generator-core/api/kt-schema-generator-core.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.api
@@ -11,6 +11,20 @@ public final class me/kpavlov/kt/schema/generator/core/ConfigKt {
 	public static final fun defaultOpaqueTypeNames ()Ljava/util/Set;
 }
 
+public final class me/kpavlov/kt/schema/generator/core/GlobMatcher {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun getExcludePatterns ()Ljava/util/List;
+	public final fun getIncludePatterns ()Ljava/util/List;
+	public final fun matches (Ljava/lang/String;)Z
+	public final fun matchesExclude (Ljava/lang/String;)Z
+	public final fun matchesInclude (Ljava/lang/String;)Z
+}
+
+public final class me/kpavlov/kt/schema/generator/core/GlobMatcherKt {
+	public static final fun globToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
+	public static final fun parseGlobPatterns (Ljava/lang/String;)Ljava/util/List;
+}
+
 public abstract interface annotation class me/kpavlov/kt/schema/generator/core/InternalSchemaGeneratorApi : java/lang/annotation/Annotation {
 }
 

--- a/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
@@ -349,6 +349,19 @@ final class me.kpavlov.kt.schema.generator.core.ir/TypeId { // me.kpavlov.kt.sch
     final fun toString(): kotlin/String // me.kpavlov.kt.schema.generator.core.ir/TypeId.toString|toString(){}[0]
 }
 
+final class me.kpavlov.kt.schema.generator.core/GlobMatcher { // me.kpavlov.kt.schema.generator.core/GlobMatcher|null[0]
+    constructor <init>(kotlin.collections/List<kotlin/String>, kotlin.collections/List<kotlin/String>) // me.kpavlov.kt.schema.generator.core/GlobMatcher.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>){}[0]
+
+    final val excludePatterns // me.kpavlov.kt.schema.generator.core/GlobMatcher.excludePatterns|{}excludePatterns[0]
+        final fun <get-excludePatterns>(): kotlin.collections/List<kotlin/String> // me.kpavlov.kt.schema.generator.core/GlobMatcher.excludePatterns.<get-excludePatterns>|<get-excludePatterns>(){}[0]
+    final val includePatterns // me.kpavlov.kt.schema.generator.core/GlobMatcher.includePatterns|{}includePatterns[0]
+        final fun <get-includePatterns>(): kotlin.collections/List<kotlin/String> // me.kpavlov.kt.schema.generator.core/GlobMatcher.includePatterns.<get-includePatterns>|<get-includePatterns>(){}[0]
+
+    final fun matches(kotlin/String): kotlin/Boolean // me.kpavlov.kt.schema.generator.core/GlobMatcher.matches|matches(kotlin.String){}[0]
+    final fun matchesExclude(kotlin/String): kotlin/Boolean // me.kpavlov.kt.schema.generator.core/GlobMatcher.matchesExclude|matchesExclude(kotlin.String){}[0]
+    final fun matchesInclude(kotlin/String): kotlin/Boolean // me.kpavlov.kt.schema.generator.core/GlobMatcher.matchesInclude|matchesInclude(kotlin.String){}[0]
+}
+
 final object me.kpavlov.kt.schema.generator.core.ir/Introspections { // me.kpavlov.kt.schema.generator.core.ir/Introspections|null[0]
     final fun getDescriptionFromAnnotation(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/Introspections.getDescriptionFromAnnotation|getDescriptionFromAnnotation(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
     final fun getNameOverride(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/Introspections.getNameOverride|getNameOverride(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
@@ -356,3 +369,5 @@ final object me.kpavlov.kt.schema.generator.core.ir/Introspections { // me.kpavl
 }
 
 final fun me.kpavlov.kt.schema.generator.core/defaultOpaqueTypeNames(): kotlin.collections/Set<kotlin/String> // me.kpavlov.kt.schema.generator.core/defaultOpaqueTypeNames|defaultOpaqueTypeNames(){}[0]
+final fun me.kpavlov.kt.schema.generator.core/globToRegex(kotlin/String): kotlin.text/Regex // me.kpavlov.kt.schema.generator.core/globToRegex|globToRegex(kotlin.String){}[0]
+final fun me.kpavlov.kt.schema.generator.core/parseGlobPatterns(kotlin/String?): kotlin.collections/List<kotlin/String> // me.kpavlov.kt.schema.generator.core/parseGlobPatterns|parseGlobPatterns(kotlin.String?){}[0]

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/GlobMatcher.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/GlobMatcher.kt
@@ -1,0 +1,98 @@
+package me.kpavlov.kt.schema.generator.core
+
+/**
+ * Matches fully qualified type names against include/exclude glob patterns.
+ *
+ * Filtering order matches the KSP processor's `SymbolFilter`:
+ * 1. Include patterns: if non-empty, the name must match at least one.
+ * 2. Exclude patterns: a name matching any of these is dropped.
+ *
+ * Glob syntax: `*` matches any sequence of non-`.` characters; `**` matches any sequence
+ * including `.`; `?` matches a single non-`.` character. All other characters are matched
+ * literally.
+ *
+ * @param includePatterns glob patterns; if non-empty, a name must match at least one to be included.
+ * @param excludePatterns glob patterns; a name matching any of these is excluded.
+ */
+public class GlobMatcher(
+    public val includePatterns: List<String>,
+    public val excludePatterns: List<String>,
+) {
+    private val includeRegexes = includePatterns.map(::globToRegex)
+    private val excludeRegexes = excludePatterns.map(::globToRegex)
+
+    /**
+     * Returns `true` when [name] matches at least one include pattern, or when no include
+     * patterns are configured. Never `true` for an excluded name.
+     */
+    public fun matches(name: String): Boolean {
+        val included = includeRegexes.isEmpty() || includeRegexes.any { it.matches(name) }
+        val excluded = excludeRegexes.isNotEmpty() && excludeRegexes.any { it.matches(name) }
+        return included && !excluded
+    }
+
+    /**
+     * Returns `true` when [name] matches at least one include pattern.
+     * Returns `false` when no include patterns are configured.
+     */
+    public fun matchesInclude(name: String): Boolean = includeRegexes.any { it.matches(name) }
+
+    /**
+     * Returns `true` when [name] matches at least one exclude pattern.
+     */
+    public fun matchesExclude(name: String): Boolean = excludeRegexes.any { it.matches(name) }
+}
+
+/**
+ * Splits a processor option value into glob patterns, trimming each token and dropping blanks.
+ * Tokens may be separated by commas or semicolons. A `null` or blank value yields an empty list.
+ */
+public fun parseGlobPatterns(value: String?): List<String> =
+    value
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.split(Regex("[,;]"))
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        .orEmpty()
+
+/**
+ * Converts a glob pattern to a [Regex].
+ *
+ * - `**` matches any sequence of characters including `.`
+ * - `*` matches any sequence of non-`.` characters
+ * - `?` matches a single non-`.` character
+ * - All other characters are matched literally.
+ */
+public fun globToRegex(glob: String): Regex {
+    val regex =
+        buildString {
+            append('^')
+            var i = 0
+            while (i < glob.length) {
+                when {
+                    glob[i] == '*' && i + 1 < glob.length && glob[i + 1] == '*' -> {
+                        append(".*")
+                        i += 2
+                    }
+
+                    glob[i] == '*' -> {
+                        append("[^.]*")
+                        i++
+                    }
+
+                    glob[i] == '?' -> {
+                        append("[^.]")
+                        i++
+                    }
+
+                    else -> {
+                        append(Regex.escape(glob[i].toString()))
+                        i++
+                    }
+                }
+            }
+            append('$')
+        }
+    return Regex(regex)
+}

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/GlobMatcherTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/GlobMatcherTest.kt
@@ -1,0 +1,164 @@
+package me.kpavlov.kt.schema.generator.core
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GlobMatcherTest {
+
+    //region globToRegex
+
+    @ParameterizedTest(name = "glob `{0}` on `{1}` → {2}")
+    @MethodSource("globMatchCases")
+    fun `globToRegex matches correctly`(
+        glob: String,
+        input: String,
+        expected: Boolean,
+    ) {
+        globToRegex(glob).matches(input) shouldBe expected
+    }
+
+    fun globMatchCases() =
+        listOf(
+            // single star — matches within one dot-segment only
+            Arguments.of("com.example.*", "com.example.Foo", true),
+            Arguments.of("com.example.*", "com.example.FooBar", true),
+            Arguments.of("com.example.*", "com.example.sub.Foo", false),
+            Arguments.of("com.example.*", "com.other.Foo", false),
+            // double star — matches across dots
+            Arguments.of("com.example.**", "com.example.Foo", true),
+            Arguments.of("com.example.**", "com.example.sub.Foo", true),
+            Arguments.of("com.example.**", "com.example.a.b.c.Foo", true),
+            Arguments.of("com.example.**", "com.other.Foo", false),
+            // suffix glob
+            Arguments.of("**.*Dto", "com.example.UserDto", true),
+            Arguments.of("**.*Dto", "com.example.sub.OrderDto", true),
+            Arguments.of("**.*Dto", "com.example.UserService", false),
+            // question mark — single non-dot character
+            Arguments.of("com.example.Fo?", "com.example.Foo", true),
+            Arguments.of("com.example.Fo?", "com.example.For", true),
+            Arguments.of("com.example.Fo?", "com.example.Fo", false),
+            Arguments.of("com.example.Fo?", "com.example.Fooo", false),
+            Arguments.of("com.example.Fo?", "com.example.F.o", false),
+            // exact match
+            Arguments.of("com.example.MyClass", "com.example.MyClass", true),
+            Arguments.of("com.example.MyClass", "com.example.MyClassX", false),
+            Arguments.of("com.example.MyClass", "com.other.MyClass", false),
+        )
+
+    //endregion
+
+    //region parseGlobPatterns
+
+    @ParameterizedTest(name = "`{0}` → {1}")
+    @MethodSource("parsePatternsCases")
+    fun `parseGlobPatterns splits and trims tokens`(
+        value: String?,
+        expected: List<String>,
+    ) {
+        parseGlobPatterns(value) shouldBe expected
+    }
+
+    fun parsePatternsCases() =
+        listOf(
+            Arguments.of(null, emptyList<String>()),
+            Arguments.of("", emptyList<String>()),
+            Arguments.of("   ", emptyList<String>()),
+            Arguments.of("com.example.**", listOf("com.example.**")),
+            Arguments.of("  com.example.*  ", listOf("com.example.*")),
+            Arguments.of("**.*Dto, **.*Service", listOf("**.*Dto", "**.*Service")),
+            Arguments.of("**.*Dto;**.*Service", listOf("**.*Dto", "**.*Service")),
+            Arguments.of("**.*Dto, ; **.*Service", listOf("**.*Dto", "**.*Service")),
+        )
+
+    //endregion
+
+    //region GlobMatcher
+
+    data class MatcherCase(
+        val description: String,
+        val name: String,
+        val include: List<String>,
+        val exclude: List<String>,
+        val expectedMatches: Boolean,
+        val expectedInclude: Boolean,
+        val expectedExclude: Boolean,
+    ) {
+        override fun toString() = description
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("matcherCases")
+    fun `GlobMatcher filters names correctly`(case: MatcherCase) {
+        val matcher = GlobMatcher(case.include, case.exclude)
+        assertSoftly(matcher) {
+            matches(case.name) shouldBe case.expectedMatches
+            matchesInclude(case.name) shouldBe case.expectedInclude
+            matchesExclude(case.name) shouldBe case.expectedExclude
+        }
+    }
+
+    fun matcherCases() =
+        listOf(
+            MatcherCase(
+                description = "no patterns includes everything",
+                name = "com.example.Foo",
+                include = emptyList(),
+                exclude = emptyList(),
+                expectedMatches = true,
+                expectedInclude = false,
+                expectedExclude = false,
+            ),
+            MatcherCase(
+                description = "include match includes the name",
+                name = "com.example.Foo",
+                include = listOf("com.example.*"),
+                exclude = emptyList(),
+                expectedMatches = true,
+                expectedInclude = true,
+                expectedExclude = false,
+            ),
+            MatcherCase(
+                description = "include non-match excludes the name",
+                name = "com.other.Foo",
+                include = listOf("com.example.*"),
+                exclude = emptyList(),
+                expectedMatches = false,
+                expectedInclude = false,
+                expectedExclude = false,
+            ),
+            MatcherCase(
+                description = "exclude match drops an included name",
+                name = "com.example.internal.Foo",
+                include = listOf("com.example.**"),
+                exclude = listOf("**.internal.**"),
+                expectedMatches = false,
+                expectedInclude = true,
+                expectedExclude = true,
+            ),
+            MatcherCase(
+                description = "exclude without include still drops",
+                name = "com.example.Foo",
+                include = emptyList(),
+                exclude = listOf("com.example.Foo"),
+                expectedMatches = false,
+                expectedInclude = false,
+                expectedExclude = true,
+            ),
+            MatcherCase(
+                description = "multiple include patterns - any match includes",
+                name = "com.example.OrderService",
+                include = listOf("**.*Dto", "**.*Service"),
+                exclude = emptyList(),
+                expectedMatches = true,
+                expectedInclude = true,
+                expectedExclude = false,
+            ),
+        )
+
+    //endregion
+}

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/SymbolFilter.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/SymbolFilter.kt
@@ -3,6 +3,8 @@ package me.kpavlov.kt.schema.ksp
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
+import me.kpavlov.kt.schema.generator.core.GlobMatcher
+import me.kpavlov.kt.schema.generator.core.parseGlobPatterns
 
 /**
  * Filters [KSClassDeclaration] and [KSFunctionDeclaration] symbols from a mixed sequence,
@@ -15,8 +17,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
  *    A declaration with no qualified name is excluded when any include pattern is present.
  * 4. Exclude patterns: a declaration matching any of these is dropped.
  *
- * Glob syntax: `*` matches any sequence of non-`.` characters; `**` matches any sequence
- * including `.`; `?` matches a single non-`.` character.
+ * Glob matching is delegated to [GlobMatcher]; glob syntax is documented there.
  *
  * Prefer constructing via [fromOptions] when reading directly from KSP processor options.
  *
@@ -43,8 +44,7 @@ internal class SymbolFilter(
     excludePatterns: List<String>,
     private val logger: KSPLogger,
 ) {
-    private val includeRegexes = includePatterns.map { globToRegex(it) }
-    private val excludeRegexes = excludePatterns.map { globToRegex(it) }
+    private val globMatcher = GlobMatcher(includePatterns, excludePatterns)
 
     companion object {
         /**
@@ -65,19 +65,10 @@ internal class SymbolFilter(
             logger: KSPLogger,
         ) = SymbolFilter(
             rootPackage = rootPackage?.trim()?.takeIf { it.isNotEmpty() },
-            includePatterns = includeOption.parsePatterns(),
-            excludePatterns = excludeOption.parsePatterns(),
+            includePatterns = parseGlobPatterns(includeOption),
+            excludePatterns = parseGlobPatterns(excludeOption),
             logger = logger,
         )
-
-        private fun String?.parsePatterns(): List<String> =
-            this
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-                ?.split(Regex("[,;]"))
-                ?.map { it.trim() }
-                ?.filter { it.isNotEmpty() }
-                .orEmpty()
     }
 
     inline fun <reified T : KSDeclaration> filter(symbols: Sequence<KSAnnotated>): Sequence<T> =
@@ -88,51 +79,7 @@ internal class SymbolFilter(
 
     @Suppress("ReturnCount")
     private fun matchesPatterns(name: String?): Boolean {
-        if (includeRegexes.isEmpty() && excludeRegexes.isEmpty()) return true
-        if (name == null) return includeRegexes.isEmpty()
-        val included = includeRegexes.isEmpty() || includeRegexes.any { it.matches(name) }
-        val excluded = excludeRegexes.isNotEmpty() && excludeRegexes.any { it.matches(name) }
-        return included && !excluded
+        if (name == null) return globMatcher.includePatterns.isEmpty()
+        return globMatcher.matches(name)
     }
-}
-
-/**
- * Converts a glob pattern to a [Regex].
- *
- * - `**` matches any sequence of characters including `.`
- * - `*` matches any sequence of non-`.` characters
- * - `?` matches a single non-`.` character
- * - All other characters are matched literally.
- */
-internal fun globToRegex(glob: String): Regex {
-    val regex =
-        buildString {
-            append('^')
-            var i = 0
-            while (i < glob.length) {
-                when {
-                    glob[i] == '*' && i + 1 < glob.length && glob[i + 1] == '*' -> {
-                        append(".*")
-                        i += 2
-                    }
-
-                    glob[i] == '*' -> {
-                        append("[^.]*")
-                        i++
-                    }
-
-                    glob[i] == '?' -> {
-                        append("[^.]")
-                        i++
-                    }
-
-                    else -> {
-                        append(Regex.escape(glob[i].toString()))
-                        i++
-                    }
-                }
-            }
-            append('$')
-        }
-    return Regex(regex)
 }

--- a/kt-schema-ksp/src/test/kotlin/me/kpavlov/kt/schema/ksp/SymbolFilterTest.kt
+++ b/kt-schema-ksp/src/test/kotlin/me/kpavlov/kt/schema/ksp/SymbolFilterTest.kt
@@ -13,7 +13,6 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -46,48 +45,6 @@ class SymbolFilterTest {
             .filter<T>(symbols.asSequence())
             .map { it.qualifiedName!!.asString() }
             .toList()
-
-    //region globToRegex
-
-    @ParameterizedTest(name = "glob `{0}` on `{1}` → {2}")
-    @MethodSource("globMatchCases")
-    fun `globToRegex matches correctly`(
-        glob: String,
-        input: String,
-        expected: Boolean,
-    ) {
-        globToRegex(glob).matches(input) shouldBe expected
-    }
-
-    fun globMatchCases() =
-        listOf(
-            // single star — matches within one dot-segment only
-            Arguments.of("com.example.*", "com.example.Foo", true),
-            Arguments.of("com.example.*", "com.example.FooBar", true),
-            Arguments.of("com.example.*", "com.example.sub.Foo", false),
-            Arguments.of("com.example.*", "com.other.Foo", false),
-            // double star — matches across dots
-            Arguments.of("com.example.**", "com.example.Foo", true),
-            Arguments.of("com.example.**", "com.example.sub.Foo", true),
-            Arguments.of("com.example.**", "com.example.a.b.c.Foo", true),
-            Arguments.of("com.example.**", "com.other.Foo", false),
-            // suffix glob
-            Arguments.of("**.*Dto", "com.example.UserDto", true),
-            Arguments.of("**.*Dto", "com.example.sub.OrderDto", true),
-            Arguments.of("**.*Dto", "com.example.UserService", false),
-            // question mark — single non-dot character
-            Arguments.of("com.example.Fo?", "com.example.Foo", true),
-            Arguments.of("com.example.Fo?", "com.example.For", true),
-            Arguments.of("com.example.Fo?", "com.example.Fo", false),
-            Arguments.of("com.example.Fo?", "com.example.Fooo", false),
-            Arguments.of("com.example.Fo?", "com.example.F.o", false),
-            // exact match
-            Arguments.of("com.example.MyClass", "com.example.MyClass", true),
-            Arguments.of("com.example.MyClass", "com.example.MyClassX", false),
-            Arguments.of("com.example.MyClass", "com.other.MyClass", false),
-        )
-
-    //endregion
 
     //region filterClasses and filterFunctions — pattern filtering
 


### PR DESCRIPTION
## Description

The change adds shared glob parsing and matching for include and exclude patterns. KSP now uses the shared matcher. APT discovery applies package, annotation, include, and exclude rules. APT tests add coverage for filtering, nested schemas, collections, maps, and descriptions. Integration tests validate generated schema resources. Documentation defines the new configuration and glob syntax.

### New Features

- Added include and exclude glob-pattern filtering for schema generation.
- Added support for filtering unannotated classes and records when explicitly included.
- Added schema generation coverage for collections and maps containing nested objects.
- Added sample `Address` and `Catalog` models.

### Documentation

- Updated configuration guidance and Maven/Gradle examples for package, include, and exclude filtering.

### Tests

- Expanded integration and filtering coverage, including nested packages, annotations, and glob matching.


**Related Issues:**  #74

---

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [x] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
