### PR TITLE
feat: Jackson annotations support (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,6 +1188,14 @@ The library automatically recognizes these description annotations by default:
 | `com.fasterxml.jackson.annotation.JsonClassDescription`    | `JsonClassDescription`    | Jackson           | `@JsonClassDescription("User model")` |
 | `dev.langchain4j.model.output.structured.P`                | `P`                       | LangChain4j       | `@P("Search query")`                  |
 
+Beyond descriptions, kt-schema also recognizes **name overrides** and **ignore markers** by default:
+
+| Annotation | FQN (matched) | Maps to |
+|---|---|---|
+| `com.fasterxml.jackson.annotation.JsonProperty` | `JsonProperty` | property **name** in `properties`/`required` |
+| `com.fasterxml.jackson.annotation.JsonTypeName` | `JsonTypeName` | polymorphic subtype name (`$defs` key + discriminator `const`) |
+| `com.fasterxml.jackson.annotation.JsonIgnore` | `JsonIgnore` | excludes the property/field from the schema |
+
 ### How It Works
 
 The introspector matches annotations by their **simple name only**, not the fully qualified name. This means:
@@ -1213,8 +1221,8 @@ By default, the library recognizes:
 
 **Description annotations**: Description, LLMDescription, JsonPropertyDescription, JsonClassDescription, P
 **Description attributes**: value, description
-**Ignore annotations**: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType
-**Name-override annotations**: kotlinx.serialization.SerialName (matched by fully qualified name)
+**Ignore annotations**: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType, JsonIgnore
+**Name-override annotations**: kotlinx.serialization.SerialName, com.fasterxml.jackson.annotation.JsonProperty, com.fasterxml.jackson.annotation.JsonTypeName
 **Name-override attributes**: value
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -1190,15 +1190,24 @@ The library automatically recognizes these description annotations by default:
 
 Beyond descriptions, kt-schema also recognizes **name overrides** and **ignore markers** by default:
 
-| Annotation | FQN (matched) | Maps to |
-|---|---|---|
-| `com.fasterxml.jackson.annotation.JsonProperty` | `JsonProperty` | property **name** in `properties`/`required` |
-| `com.fasterxml.jackson.annotation.JsonTypeName` | `JsonTypeName` | polymorphic subtype name (`$defs` key + discriminator `const`) |
-| `com.fasterxml.jackson.annotation.JsonIgnore` | `JsonIgnore` | excludes the property/field from the schema |
+**Name overrides** — matched by **fully qualified name** (case-sensitive):
+
+| Annotation                                      | Maps to                                                        |
+|-------------------------------------------------|----------------------------------------------------------------|
+| `com.fasterxml.jackson.annotation.JsonProperty` | property **name** in `properties`/`required`                   |
+| `com.fasterxml.jackson.annotation.JsonTypeName` | polymorphic subtype name (`$defs` key + discriminator `const`) |
+
+**Ignore markers** — matched by **simple name** (case-insensitive), regardless of package:
+
+| Annotation                 | Maps to                                     |
+|----------------------------|---------------------------------------------|
+| `JsonIgnore` (any package) | excludes the property/field from the schema |
 
 ### How It Works
 
-The introspector matches annotations by their **simple name only**, not the fully qualified name. This means:
+Each annotation category (description, name-override, ignore) is configured with its own list of recognized names.
+Within a list, entries containing a dot are matched **case-sensitively** against the fully qualified name; entries
+without a dot are matched **case-insensitively** against the simple name. This means:
 
 - ✅ No code changes needed to generate schemas from existing annotated classes
 - ✅ Can migrate between annotation libraries without modifying code
@@ -1206,7 +1215,8 @@ The introspector matches annotations by their **simple name only**, not the full
 - ✅ Use your preferred annotation library while still getting schema generation
 
 > [!NOTE]
-> Multi-framework annotation recognition applies to the **KSP processor** and **reflection-based generators**.
+> Multi-framework annotation recognition applies to the **KSP processor**, the **Java APT processor**
+> (via `AptIntrospectionContext`, which recognizes the same Jackson defaults), and **reflection-based generators**.
 > The serialization-based generator (`SerializationClassJsonSchemaGenerator`) can only access annotations marked
 > with `@SerialInfo` — see [Custom description extraction](docs/serializable.md#custom-description-extraction) for details.
 

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Company.java
@@ -1,22 +1,30 @@
 package me.kpavlov.kt.schema.apt.integration.type;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 /**
- * Simple test model to verify plain (non-record) Java class schema generation.
+ * Simple test model to verify plain (non-record) Java class schema generation,
+ * including Jackson name overrides and ignored fields.
  */
 @JsonClassDescription("A company with a name and a founding year.")
 public class Company {
 
+    @JsonProperty("company_name")
     @JsonPropertyDescription("Name of the company")
     private final String name;
 
     @JsonPropertyDescription("Year the company was founded")
     private final int founded;
 
-    public Company(String name, int founded) {
+    @JsonIgnore
+    private final String taxId;
+
+    public Company(String name, int founded, String taxId) {
         this.name = name;
         this.founded = founded;
+        this.taxId = taxId;
     }
 }

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Person.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Person.java
@@ -1,14 +1,18 @@
 package me.kpavlov.kt.schema.apt.integration.type;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 /**
- * Simple test model to verify basic Java annotation-processor schema generation.
+ * Simple test model to verify basic Java annotation-processor schema generation,
+ * including Jackson name overrides and ignored properties.
  */
 @JsonClassDescription("A person with a first and last name and age.")
 public record Person(
-        @JsonPropertyDescription("Given name of the person") String firstName,
+        @JsonProperty("given_name") @JsonPropertyDescription("Given name of the person") String firstName,
         @JsonPropertyDescription("Family name of the person") String lastName,
-        @JsonPropertyDescription("Age of the person in years") int age) {
+        @JsonPropertyDescription("Age of the person in years") int age,
+        @JsonIgnore String ssn) {
 }

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/CompanySchemaTest.java
@@ -31,7 +31,7 @@ class CompanySchemaTest {
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "name": {
+                    "company_name": {
                       "type": "string",
                       "description": "Name of the company"
                     },
@@ -40,7 +40,7 @@ class CompanySchemaTest {
                       "description": "Year the company was founded"
                     }
                   },
-                  "required": ["name", "founded"],
+                  "required": ["company_name", "founded"],
                   "additionalProperties": false,
                   "description": "A company with a name and a founding year."
                 }

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PersonSchemaTest.java
@@ -31,7 +31,7 @@ class PersonSchemaTest {
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "firstName": {
+                    "given_name": {
                       "type": "string",
                       "description": "Given name of the person"
                     },
@@ -44,7 +44,7 @@ class PersonSchemaTest {
                       "description": "Age of the person in years"
                     }
                   },
-                  "required": ["firstName", "lastName", "age"],
+                  "required": ["given_name", "lastName", "age"],
                   "additionalProperties": false,
                   "description": "A person with a first and last name and age."
                 }

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModel.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModel.kt
@@ -31,6 +31,9 @@ data class JacksonModel(
     val internalNote: String = "hidden",
     @get:JsonIgnore
     val sessionId: String = "session",
+    @get:JsonProperty("stock_keeping_unit")
+    @get:JsonPropertyDescription("Stock keeping unit code")
+    val sku: String = "sku",
 )
 
 @Schema

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModel.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModel.kt
@@ -1,18 +1,22 @@
 package me.kpavlov.kt.schema.integration.type
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import me.kpavlov.kt.schema.Schema
 
 /**
- * Model with Jackson @JsonClassDescription and @JsonPropertyDescription annotations
- * to test description extraction
+ * Model with Jackson @JsonClassDescription, @JsonPropertyDescription, @JsonProperty
+ * and @JsonIgnore annotations to test description and name extraction.
  */
 @JsonClassDescription("A purchasable product using Jackson annotations.")
 @Schema
 data class JacksonModel(
+    @JsonProperty("product_id")
     @JsonPropertyDescription("Unique identifier for the product")
     val id: Long,
+    @JsonProperty("display_name")
     @JsonPropertyDescription("Human-readable product name")
     val name: String,
     @JsonPropertyDescription("Optional detailed description of the product")
@@ -23,6 +27,10 @@ data class JacksonModel(
     val inStock: Boolean = true,
     @JsonPropertyDescription("List of tags for categorization and search")
     val tags: List<String> = emptyList(),
+    @JsonIgnore
+    val internalNote: String = "hidden",
+    @get:JsonIgnore
+    val sessionId: String = "session",
 )
 
 @Schema

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonShape.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonShape.kt
@@ -1,0 +1,19 @@
+package me.kpavlov.kt.schema.integration.type
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import me.kpavlov.kt.schema.Description
+import me.kpavlov.kt.schema.Schema
+
+/**
+ * Sealed hierarchy using Jackson @JsonTypeName to override the polymorphic
+ * discriminator value and $defs key for each subtype.
+ */
+@Schema
+@Description("A shape described with Jackson @JsonTypeName annotations.")
+sealed class JacksonShape {
+    @JsonTypeName("circle")
+    data class Circle(val radius: Double) : JacksonShape()
+
+    @JsonTypeName("square")
+    data class Square(val side: Double) : JacksonShape()
+}

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModelSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModelSchemaTest.kt
@@ -47,9 +47,13 @@ class JacksonModelSchemaTest {
                   "items": {
                     "type": "string"
                   }
+                },
+                "stock_keeping_unit": {
+                  "type": "string",
+                  "description": "Stock keeping unit code"
                 }
               },
-              "required": ["product_id", "display_name", "description", "price", "inStock", "tags"],
+              "required": ["product_id", "display_name", "description", "price", "inStock", "tags", "stock_keeping_unit"],
               "additionalProperties": false
             }
             """.trimIndent()

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModelSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonModelSchemaTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
  */
 class JacksonModelSchemaTest {
     @Test
-    fun `extracts descriptions from Jackson annotations`() {
+    fun `extracts descriptions and names from Jackson annotations`() {
         val schema = JacksonModel::class.jsonSchemaString
 
         // language=json
@@ -21,11 +21,11 @@ class JacksonModelSchemaTest {
               "description": "A purchasable product using Jackson annotations.",
               "type": "object",
               "properties": {
-                "id": {
+                "product_id": {
                   "type": "integer",
                   "description": "Unique identifier for the product"
                 },
-                "name": {
+                "display_name": {
                   "type": "string",
                   "description": "Human-readable product name"
                 },
@@ -49,7 +49,7 @@ class JacksonModelSchemaTest {
                   }
                 }
               },
-              "required": ["id", "name", "description", "price", "inStock", "tags"],
+              "required": ["product_id", "display_name", "description", "price", "inStock", "tags"],
               "additionalProperties": false
             }
             """.trimIndent()

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonShapeSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonShapeSchemaTest.kt
@@ -1,0 +1,70 @@
+package me.kpavlov.kt.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/**
+ * Tests for Jackson @JsonTypeName polymorphic subtype naming.
+ */
+class JacksonShapeSchemaTest {
+    @Test
+    fun `@JsonTypeName overrides subtype names in defs and discriminator`() {
+        val schema = JacksonShape::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.integration.type.JacksonShape",
+              "description": "A shape described with Jackson @JsonTypeName annotations.",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/circle"
+                },
+                {
+                  "$ref": "#/$defs/square"
+                }
+              ],
+              "$defs": {
+                "circle": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "circle"
+                    },
+                    "radius": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "radius"
+                  ],
+                  "additionalProperties": false
+                },
+                "square": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "square"
+                    },
+                    "side": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "side"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -253,8 +253,14 @@ internal class AptIntrospectionContext(
 
                 element.recordComponents.forEach { component ->
                     val name = component.simpleName.toString()
-                    required += name
-                    props += toProperty(name, component.asType(), recordComponentDescription(component, element))
+                    val field = fieldFor(element, name)
+                    val targets = listOfNotNull(component, component.accessor, field)
+                    // Skip components marked with an ignore annotation (e.g. @JsonIgnore)
+                    if (isIgnored(*targets.toTypedArray())) return@forEach
+                    val propertyName = nameOverrideFor(*targets.toTypedArray()) ?: name
+                    required += propertyName
+                    val description = recordComponentDescription(component, field)
+                    props += toProperty(propertyName, component.asType(), description)
                 }
 
                 objectNode(element, props, required)
@@ -280,8 +286,11 @@ internal class AptIntrospectionContext(
                     .filter { it.kind == ElementKind.FIELD && !it.modifiers.contains(Modifier.STATIC) }
                     .forEach { field ->
                         val name = field.simpleName.toString()
-                        required += name
-                        props += toProperty(name, field.asType(), extractDescription(field))
+                        // Skip fields marked with an ignore annotation (e.g. @JsonIgnore)
+                        if (isIgnored(field)) return@forEach
+                        val propertyName = nameOverrideFor(field) ?: name
+                        required += propertyName
+                        props += toProperty(propertyName, field.asType(), extractDescription(field))
                     }
 
                 objectNode(element, props, required)
@@ -308,7 +317,9 @@ internal class AptIntrospectionContext(
                     .filter { !it.modifiers.contains(Modifier.STATIC) }
                     .filter { it.parameters.isEmpty() && it.returnType.kind != TypeKind.VOID }
                     .forEach { method ->
-                        val name = propertyName(method.simpleName.toString())
+                        // Skip accessors marked with an ignore annotation (e.g. @JsonIgnore)
+                        if (isIgnored(method)) return@forEach
+                        val name = nameOverrideFor(method) ?: propertyName(method.simpleName.toString())
                         required += name
                         props += toProperty(name, method.returnType, extractDescription(method))
                     }
@@ -427,7 +438,7 @@ internal class AptIntrospectionContext(
         required: Set<String>,
     ): ObjectNode =
         ObjectNode(
-            name = element.qualifiedName.toString(),
+            name = nameOverrideFor(element) ?: element.qualifiedName.toString(),
             properties = properties,
             required = required,
             description = extractDescription(element),
@@ -443,11 +454,11 @@ internal class AptIntrospectionContext(
      */
     private fun recordComponentDescription(
         component: RecordComponentElement,
-        type: TypeElement,
+        field: VariableElement?,
     ): String? =
         extractDescription(component)
             ?: extractDescription(component.accessor)
-            ?: fieldFor(type, component.simpleName.toString())?.let(::extractDescription)
+            ?: field?.let(::extractDescription)
 
     /**
      * Record component annotations propagate to the backing field (among other targets),
@@ -473,6 +484,43 @@ internal class AptIntrospectionContext(
                 simpleName = annotationElement.simpleName.toString(),
                 qualifiedName = annotationElement.qualifiedName.toString(),
                 annotationArguments = args,
+            )
+        }
+
+    /**
+     * Returns the first name-override value (e.g. from `@JsonProperty`, `@JsonTypeName`)
+     * found across the given annotation targets, in order, or null if none provides one.
+     */
+    private fun nameOverrideFor(vararg targets: Element): String? =
+        targets.firstNotNullOfOrNull(::extractNameOverride)
+
+    private fun extractNameOverride(element: Element): String? =
+        element.annotationMirrors.firstNotNullOfOrNull { mirror ->
+            val annotationElement = mirror.annotationType.asElement() as TypeElement
+            val args =
+                mirror.elementValues.entries.map { (attribute, value) ->
+                    attribute.simpleName.toString() to value.value
+                }
+            Introspections.getNameOverride(
+                simpleName = annotationElement.simpleName.toString(),
+                qualifiedName = annotationElement.qualifiedName.toString(),
+                annotationArguments = args,
+            )
+        }
+
+    /**
+     * Returns `true` if any of the given annotation targets carries a recognized
+     * ignore annotation (e.g. `@JsonIgnore`).
+     */
+    private fun isIgnored(vararg targets: Element): Boolean =
+        targets.any(::isIgnoreAnnotation)
+
+    private fun isIgnoreAnnotation(element: Element): Boolean =
+        element.annotationMirrors.any { mirror ->
+            val annotationElement = mirror.annotationType.asElement() as TypeElement
+            Introspections.isIgnoreAnnotation(
+                simpleName = annotationElement.simpleName.toString(),
+                qualifiedName = annotationElement.qualifiedName.toString(),
             )
         }
 

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -256,8 +256,8 @@ internal class AptIntrospectionContext(
                     val field = fieldFor(element, name)
                     val targets = listOfNotNull(component, component.accessor, field)
                     // Skip components marked with an ignore annotation (e.g. @JsonIgnore)
-                    if (isIgnored(*targets.toTypedArray())) return@forEach
-                    val propertyName = nameOverrideFor(*targets.toTypedArray()) ?: name
+                    if (isIgnored(targets)) return@forEach
+                    val propertyName = nameOverrideFor(targets) ?: name
                     required += propertyName
                     val description = recordComponentDescription(component, field)
                     props += toProperty(propertyName, component.asType(), description)
@@ -287,8 +287,8 @@ internal class AptIntrospectionContext(
                     .forEach { field ->
                         val name = field.simpleName.toString()
                         // Skip fields marked with an ignore annotation (e.g. @JsonIgnore)
-                        if (isIgnored(field)) return@forEach
-                        val propertyName = nameOverrideFor(field) ?: name
+                        if (isIgnored(listOf(field))) return@forEach
+                        val propertyName = nameOverrideFor(listOf(field)) ?: name
                         required += propertyName
                         props += toProperty(propertyName, field.asType(), extractDescription(field))
                     }
@@ -318,8 +318,8 @@ internal class AptIntrospectionContext(
                     .filter { it.parameters.isEmpty() && it.returnType.kind != TypeKind.VOID }
                     .forEach { method ->
                         // Skip accessors marked with an ignore annotation (e.g. @JsonIgnore)
-                        if (isIgnored(method)) return@forEach
-                        val name = nameOverrideFor(method) ?: propertyName(method.simpleName.toString())
+                        if (isIgnored(listOf(method))) return@forEach
+                        val name = nameOverrideFor(listOf(method)) ?: propertyName(method.simpleName.toString())
                         required += name
                         props += toProperty(name, method.returnType, extractDescription(method))
                     }
@@ -438,7 +438,7 @@ internal class AptIntrospectionContext(
         required: Set<String>,
     ): ObjectNode =
         ObjectNode(
-            name = nameOverrideFor(element) ?: element.qualifiedName.toString(),
+            name = nameOverrideFor(listOf(element)) ?: element.qualifiedName.toString(),
             properties = properties,
             required = required,
             description = extractDescription(element),
@@ -491,7 +491,7 @@ internal class AptIntrospectionContext(
      * Returns the first name-override value (e.g. from `@JsonProperty`, `@JsonTypeName`)
      * found across the given annotation targets, in order, or null if none provides one.
      */
-    private fun nameOverrideFor(vararg targets: Element): String? =
+    private fun nameOverrideFor(targets: List<Element>): String? =
         targets.firstNotNullOfOrNull(::extractNameOverride)
 
     private fun extractNameOverride(element: Element): String? =
@@ -512,7 +512,7 @@ internal class AptIntrospectionContext(
      * Returns `true` if any of the given annotation targets carries a recognized
      * ignore annotation (e.g. `@JsonIgnore`).
      */
-    private fun isIgnored(vararg targets: Element): Boolean =
+    private fun isIgnored(targets: List<Element>): Boolean =
         targets.any(::isIgnoreAnnotation)
 
     private fun isIgnoreAnnotation(element: Element): Boolean =

--- a/kt-schema-generator-core/build.gradle.kts
+++ b/kt-schema-generator-core/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
             dependencies {
                 implementation(libs.junit.jupiter.params)
                 implementation(libs.mockk)
+                implementation(libs.jackson.annotations)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.kt
@@ -97,7 +97,7 @@ internal expect object Config {
      * Loaded lazily from the `introspector.annotations.ignore.names` property in
      * `kt-schema.properties`. If loading fails, falls back to built-in defaults.
      *
-     * Default value: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType
+     * Default value: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType, JsonIgnore
      */
     val ignoreAnnotationNames: List<String>
 
@@ -111,7 +111,9 @@ internal expect object Config {
      * Loaded lazily from the `introspector.annotations.name.names` property in
      * `kt-schema.properties`. If loading fails, falls back to built-in defaults.
      *
-     * Default value: kotlinx.serialization.SerialName
+     * Default value: kotlinx.serialization.SerialName,
+     *                com.fasterxml.jackson.annotation.JsonProperty,
+     *                com.fasterxml.jackson.annotation.JsonTypeName
      */
     val nameAnnotationNames: List<String>
 

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/Introspections.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/Introspections.kt
@@ -34,7 +34,7 @@ import kotlin.jvm.JvmStatic
  * - `introspector.annotations.description.attributes`: Comma-separated list of annotation parameter
  *   names that contain description text (e.g., "value,description")
  * - `introspector.annotations.ignore.names`: Comma-separated list of annotation names
- *   to recognize as ignore markers (e.g., "SchemaIgnore,JsonIgnoreType")
+ *   to recognize as ignore markers (e.g., "SchemaIgnore,JsonIgnoreType,JsonIgnore")
  * - `introspector.annotations.name.names`: Comma-separated list of annotation names
  *   to recognize as name-override providers (e.g., "kotlinx.serialization.SerialName")
  * - `introspector.annotations.name.attributes`: Comma-separated list of annotation parameter

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.jvm.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.jvm.kt
@@ -44,6 +44,7 @@ private val DEFAULT_IGNORE_NAMES =
         "schemaignore",
         "serialschemaignore",
         "jsonignoretype",
+        "jsonignore",
     )
 
 /**
@@ -52,6 +53,8 @@ private val DEFAULT_IGNORE_NAMES =
 private val DEFAULT_NAME_ANNOTATION_NAMES =
     listOf(
         "kotlinx.serialization.SerialName",
+        "com.fasterxml.jackson.annotation.JsonProperty",
+        "com.fasterxml.jackson.annotation.JsonTypeName",
     )
 
 /**

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -343,7 +343,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             // Find the property in the current class (inherited)
             val property = findPropertyByName(klass, propertyName)
 
-            if (property != null) {
+            if (property != null && !isSchemaIgnored(property.annotations)) {
                 val typeRef = toRef(property.returnType)
                 val description = parentPropertyDescriptions[propertyName]
 
@@ -372,7 +372,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 .filterIsInstance<KProperty<*>>()
                 .filter { it.visibility == KVisibility.PUBLIC }
                 .forEach { prop ->
-                    if (prop.name !in processedProperties) {
+                    if (prop.name !in processedProperties && !isSchemaIgnored(prop.annotations)) {
                         val fixedValue = defaultValues[prop.name]
                         properties +=
                             Property(
@@ -466,10 +466,13 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             val kotlinName = param.name ?: return@forEach
             val hasDefault = param.isOptional
 
-            // Get annotations both on the constructor parameter and property associated with it
-            val annotations = param.annotations + findPropertyByName(klass, kotlinName)?.annotations.orEmpty()
+            // Collect annotations from the parameter, property, getter, and backing field
+            val annotations = collectConstructorAnnotations(klass, kotlinName, param.annotations)
 
-            // Use @SerialName override if present, otherwise use Kotlin property name
+            // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
+            if (isSchemaIgnored(annotations)) return@forEach
+
+            // Name override (e.g. @SerialName, @JsonProperty), else Kotlin property name
             val propertyName = extractNameOverride(annotations) ?: kotlinName
 
             val propertyType = param.type

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -343,7 +343,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             // Find the property in the current class (inherited)
             val property = findPropertyByName(klass, propertyName)
 
-            if (property != null && !isSchemaIgnored(property.annotations)) {
+            if (property != null && !isSchemaIgnored(collectPropertyAnnotations(property))) {
                 val typeRef = toRef(property.returnType)
                 val description = parentPropertyDescriptions[propertyName]
 
@@ -372,7 +372,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 .filterIsInstance<KProperty<*>>()
                 .filter { it.visibility == KVisibility.PUBLIC }
                 .forEach { prop ->
-                    if (prop.name !in processedProperties && !isSchemaIgnored(prop.annotations)) {
+                    if (prop.name !in processedProperties && !isSchemaIgnored(collectPropertyAnnotations(prop))) {
                         val fixedValue = defaultValues[prop.name]
                         properties +=
                             Property(

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
@@ -43,6 +43,19 @@ internal fun findPropertyByName(
         .firstOrNull { it.name == propertyName }
 
 /**
+ * Collects all annotations relevant to a property: its own annotations, its getter's,
+ * and its backing Java field's.
+ *
+ * This covers all common use-site targets (e.g. `@property:`, `@get:`, `@field:`) so
+ * annotations like `@JsonProperty` and `@JsonIgnore` are recognized regardless of
+ * where the compiler places them.
+ */
+internal fun collectPropertyAnnotations(property: KProperty<*>): List<Annotation> =
+    property.annotations +
+        property.getter.annotations +
+        property.javaField?.annotations.orEmpty()
+
+/**
  * Collects all annotations relevant to a constructor property, from the constructor
  * parameter, the Kotlin property, its getter, and its backing Java field.
  *
@@ -56,10 +69,7 @@ internal fun collectConstructorAnnotations(
     paramAnnotations: List<Annotation>,
 ): List<Annotation> {
     val property = findPropertyByName(klass, propertyName)
-    return paramAnnotations +
-        property?.annotations.orEmpty() +
-        property?.getter?.annotations.orEmpty() +
-        property?.javaField?.annotations.orEmpty()
+    return paramAnnotations + property?.let(::collectPropertyAnnotations).orEmpty()
 }
 
 /**

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
@@ -10,6 +10,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
 
@@ -40,6 +41,26 @@ internal fun findPropertyByName(
     klass.members
         .filterIsInstance<KProperty<*>>()
         .firstOrNull { it.name == propertyName }
+
+/**
+ * Collects all annotations relevant to a constructor property, from the constructor
+ * parameter, the Kotlin property, its getter, and its backing Java field.
+ *
+ * This covers all common use-site targets (e.g. `@param:`, `@property:`, `@get:`,
+ * `@field:`) so annotations like `@JsonProperty` and `@JsonIgnore` are recognized
+ * regardless of where the compiler places them.
+ */
+internal fun collectConstructorAnnotations(
+    klass: KClass<*>,
+    propertyName: String,
+    paramAnnotations: List<Annotation>,
+): List<Annotation> {
+    val property = findPropertyByName(klass, propertyName)
+    return paramAnnotations +
+        property?.annotations.orEmpty() +
+        property?.getter?.annotations.orEmpty() +
+        property?.javaField?.annotations.orEmpty()
+}
 
 /**
  * Checks whether the given list of annotations contains a recognized ignore marker

--- a/kt-schema-generator-core/src/jvmMain/resources/kt-schema.properties
+++ b/kt-schema-generator-core/src/jvmMain/resources/kt-schema.properties
@@ -32,11 +32,13 @@ introspector.annotations.description.attributes=value,description
 ## Default annotations supported:
 ## - SchemaIgnore (kt-schema)
 ## - SerialSchemaIgnore (kt-schema, serialization-aware)
-## - JsonIgnoreType (Jackson)
+## - JsonIgnoreType (Jackson, for types)
+## - JsonIgnore (Jackson, for properties/fields)
 introspector.annotations.ignore.names=\
   SchemaIgnore,\
   SerialSchemaIgnore,\
-  JsonIgnoreType
+  JsonIgnoreType,\
+  JsonIgnore
 
 ## Annotation names recognized as name-override providers
 ## Names containing a dot are treated as fully qualified names (FQN) and matched case-sensitively.
@@ -44,7 +46,12 @@ introspector.annotations.ignore.names=\
 ##
 ## Default annotations supported:
 ## - kotlinx.serialization.SerialName (kotlinx.serialization, matched by FQN)
-introspector.annotations.name.names=kotlinx.serialization.SerialName
+## - com.fasterxml.jackson.annotation.JsonProperty (Jackson, matched by FQN)
+## - com.fasterxml.jackson.annotation.JsonTypeName (Jackson, matched by FQN)
+introspector.annotations.name.names=\
+  kotlinx.serialization.SerialName,\
+  com.fasterxml.jackson.annotation.JsonProperty,\
+  com.fasterxml.jackson.annotation.JsonTypeName
 
 ## Annotation parameter names that contain name-override text
 ## Format: Comma-separated list (case-insensitive matching)

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
@@ -33,4 +33,19 @@ class ConfigTest {
         Config.descriptionAnnotationNames.all { it == it.lowercase() } shouldBe true
         Config.descriptionValueAttributes.all { it == it.lowercase() } shouldBe true
     }
+
+    @Test
+    fun `loads ignore annotation names from properties`() {
+        Config.ignoreAnnotationNames shouldContain "schemaignore"
+        Config.ignoreAnnotationNames shouldContain "serialschemaignore"
+        Config.ignoreAnnotationNames shouldContain "jsonignoretype"
+        Config.ignoreAnnotationNames shouldContain "jsonignore"
+    }
+
+    @Test
+    fun `loads name override annotation names from properties`() {
+        Config.nameAnnotationNames shouldContain "kotlinx.serialization.SerialName"
+        Config.nameAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonProperty"
+        Config.nameAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonTypeName"
+    }
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
@@ -1,5 +1,6 @@
 package me.kpavlov.kt.schema.generator.core
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
@@ -36,16 +37,20 @@ class ConfigTest {
 
     @Test
     fun `loads ignore annotation names from properties`() {
-        Config.ignoreAnnotationNames shouldContain "schemaignore"
-        Config.ignoreAnnotationNames shouldContain "serialschemaignore"
-        Config.ignoreAnnotationNames shouldContain "jsonignoretype"
-        Config.ignoreAnnotationNames shouldContain "jsonignore"
+        assertSoftly(Config.ignoreAnnotationNames) {
+            shouldContain("schemaignore")
+            shouldContain("serialschemaignore")
+            shouldContain("jsonignoretype")
+            shouldContain("jsonignore")
+        }
     }
 
     @Test
     fun `loads name override annotation names from properties`() {
-        Config.nameAnnotationNames shouldContain "kotlinx.serialization.SerialName"
-        Config.nameAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonProperty"
-        Config.nameAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonTypeName"
+        assertSoftly(Config.nameAnnotationNames) {
+            shouldContain("kotlinx.serialization.SerialName")
+            shouldContain("com.fasterxml.jackson.annotation.JsonProperty")
+            shouldContain("com.fasterxml.jackson.annotation.JsonTypeName")
+        }
     }
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ir/IntrospectionsTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ir/IntrospectionsTest.kt
@@ -100,6 +100,7 @@ class IntrospectionsTest {
         "SchemaIgnore",
         "SerialSchemaIgnore",
         "JsonIgnoreType",
+        "JsonIgnore",
     )
     fun `recognizes ignore annotations by simple name`(name: String) {
         Introspections.isIgnoreAnnotation(name) shouldBe true
@@ -120,7 +121,7 @@ class IntrospectionsTest {
     @ParameterizedTest
     @CsvSource(
         "Ignore",
-        "JsonIgnore",
+        "JsonIgnoreProperties",
         "Transient",
         "Description",
         "UnknownAnnotation",
@@ -178,6 +179,7 @@ class IntrospectionsTest {
         "SerialName, , custom_name",
         "serialname, kotlinx.serialization.serialname, custom_name",
         "SerialName, kotlinx.serialization.SerialName, ''",
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonProperty, ''",
     )
     fun `getNameOverride returns null for non-matching cases`(
         simpleName: String,
@@ -187,6 +189,47 @@ class IntrospectionsTest {
         Introspections.getNameOverride(
             simpleName = simpleName,
             qualifiedName = qualifiedName?.takeIf { it.isNotEmpty() },
+            annotationArguments = listOf("value" to inputValue),
+        ) shouldBe null
+    }
+
+    //endregion
+
+    //region Jackson name override extraction
+
+    @ParameterizedTest
+    @CsvSource(
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonProperty, user_email, user_email",
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonProperty, productId, productId",
+        "JsonTypeName, com.fasterxml.jackson.annotation.JsonTypeName, cat, cat",
+    )
+    fun `getNameOverride extracts value from Jackson annotations when FQN matches`(
+        simpleName: String,
+        qualifiedName: String,
+        inputValue: String,
+        expectedResult: String,
+    ) {
+        Introspections.getNameOverride(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
+            annotationArguments = listOf("value" to inputValue),
+        ) shouldBe expectedResult
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "JsonProperty, JsonProperty, custom_name",
+        "JsonTypeName, JsonTypeName, custom_name",
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonPropertyDescription, custom_name",
+    )
+    fun `getNameOverride matches Jackson annotations only by FQN`(
+        simpleName: String,
+        qualifiedName: String?,
+        inputValue: String,
+    ) {
+        Introspections.getNameOverride(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
             annotationArguments = listOf("value" to inputValue),
         ) shouldBe null
     }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -1,6 +1,10 @@
 package me.kpavlov.kt.schema.generator.reflect
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeName
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -81,6 +85,22 @@ class ReflectionIntrospectorTest {
         val items: List<*>,
         val mapping: Map<*, *>,
     )
+
+    @Suppress("unused")
+    data class JacksonAnnotatedUser(
+        @param:JsonProperty("user_name") val userName: String,
+        @param:JsonProperty("email_address") val emailAddress: String = "n/a",
+        @field:JsonIgnore val password: String = "secret",
+    )
+
+    @Suppress("unused")
+    sealed interface JacksonVehicle {
+        @JsonTypeName("car")
+        data class Car(val doors: Int) : JacksonVehicle
+
+        @JsonTypeName("truck")
+        data class Truck(val payload: Double) : JacksonVehicle
+    }
 
     private val introspector = ReflectionClassIntrospector
 
@@ -322,5 +342,40 @@ class ReflectionIntrospectorTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `honors Jackson @JsonProperty name override in properties and required`() {
+        val graph = introspector.introspect(JacksonAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("user_name", "email_address")
+        node.required shouldBe setOf("user_name")
+    }
+
+    @Test
+    fun `excludes properties annotated with Jackson @JsonIgnore`() {
+        val graph = introspector.introspect(JacksonAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "password"
+        node.required shouldNotContain "password"
+    }
+
+    @Test
+    fun `honors Jackson @JsonTypeName on sealed subtypes in defs and discriminator`() {
+        val graph = introspector.introspect(JacksonVehicle::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[root.id].shouldBeInstanceOf<PolymorphicNode>()
+
+        val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
+        subtypeIds.shouldContainExactlyInAnyOrder(setOf("car", "truck"))
+
+        polyNode.discriminator.mapping?.keys shouldBe setOf("car", "truck")
     }
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -102,6 +102,22 @@ class ReflectionIntrospectorTest {
         data class Truck(val payload: Double) : JacksonVehicle
     }
 
+    @Suppress("unused")
+    sealed class SealedWithHiddenParentProperty {
+        @get:JsonIgnore
+        val internalId: String = "hidden-parent"
+
+        data class Variant(val visible: Int) : SealedWithHiddenParentProperty()
+    }
+
+    @Suppress("unused")
+    object SingletonWithHiddenProperty {
+        const val visible: Int = 1
+
+        @get:JsonIgnore
+        val internalToken: String = "hidden-singleton"
+    }
+
     private val introspector = ReflectionClassIntrospector
 
     @Test
@@ -377,5 +393,27 @@ class ReflectionIntrospectorTest {
         subtypeIds.shouldContainExactlyInAnyOrder(setOf("car", "truck"))
 
         polyNode.discriminator.mapping?.keys shouldBe setOf("car", "truck")
+    }
+
+    @Test
+    fun `excludes sealed-parent inherited property annotated with @get JsonIgnore`() {
+        val graph = introspector.introspect(SealedWithHiddenParentProperty.Variant::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "internalId"
+        node.required shouldNotContain "internalId"
+    }
+
+    @Test
+    fun `excludes singleton object property annotated with @get JsonIgnore`() {
+        val graph = introspector.introspect(SingletonWithHiddenProperty::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "internalToken"
+        node.required shouldNotContain "internalToken"
     }
 }

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -323,29 +323,35 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         decl: KSClassDeclaration,
         addProperty: (String, KSType, String?, Boolean) -> Unit,
     ) {
+        val declaredProperties = decl.getDeclaredProperties().associateBy { it.simpleName.asString() }
         // Prefer primary constructor parameters for data classes; fall back to public properties
         val params = decl.primaryConstructor?.parameters.orEmpty()
         if (params.isNotEmpty()) {
             params.forEach { p ->
                 val kotlinName = p.name?.asString() ?: return@forEach
+                val property = declaredProperties[kotlinName]
+                // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
+                if (p.isSchemaIgnored() || property?.isIgnoredForSchema() == true) return@forEach
                 val propertyName = extractNameOverride(p) ?: kotlinName
                 val description = extractConstructorParamDescription(p, kotlinName, decl.docString)
                 addProperty(propertyName, p.type.resolve(), description, p.hasDefault)
             }
         } else {
-            decl.getDeclaredProperties().filter { it.isPublic() }.forEach { prop ->
-                val kotlinName = prop.simpleName.asString()
-                val propertyName = extractNameOverride(prop) ?: kotlinName
-                val description =
-                    extractPropertyDescription(
-                        annotated = prop,
-                        propertyName = kotlinName,
-                        parentKdoc = decl.docString,
-                        kdocTagName = "property",
-                        elementKdocFallback = { prop.descriptionFromKdoc() },
-                    )
-                addProperty(propertyName, prop.type.resolve(), description, false)
-            }
+            declaredProperties.values
+                .filter { it.isPublic() && !it.isIgnoredForSchema() }
+                .forEach { prop ->
+                    val kotlinName = prop.simpleName.asString()
+                    val propertyName = extractNameOverride(prop) ?: kotlinName
+                    val description =
+                        extractPropertyDescription(
+                            annotated = prop,
+                            propertyName = kotlinName,
+                            parentKdoc = decl.docString,
+                            kdocTagName = "property",
+                            elementKdocFallback = { prop.descriptionFromKdoc() },
+                        )
+                    addProperty(propertyName, prop.type.resolve(), description, false)
+                }
         }
     }
 
@@ -362,7 +368,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 .toList()
 
         sealedParents.forEach { parent ->
-            parent.getDeclaredProperties().filter { it.isPublic() }.forEach { prop ->
+            parent.getDeclaredProperties().filter { it.isPublic() && !it.isIgnoredForSchema() }.forEach { prop ->
                 val name = prop.simpleName.asString()
                 if (name !in processedProperties) {
                     val description =

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -332,8 +332,9 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 val property = declaredProperties[kotlinName]
                 // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
                 if (p.isSchemaIgnored() || property?.isIgnoredForSchema() == true) return@forEach
-                val propertyName = extractNameOverride(p) ?: kotlinName
-                val description = extractConstructorParamDescription(p, kotlinName, decl.docString)
+                val propertyName =
+                    extractNameOverride(p) ?: property?.let { extractNameOverride(it) } ?: kotlinName
+                val description = extractConstructorParamDescription(p, kotlinName, decl.docString, property)
                 addProperty(propertyName, p.type.resolve(), description, p.hasDefault)
             }
         } else {

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspUtils.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspUtils.kt
@@ -1,9 +1,22 @@
 package me.kpavlov.kt.schema.ksp.ir
 
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import me.kpavlov.kt.schema.generator.core.ir.Property
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
+
+/**
+ * Extracts a name override from an annotated element's own annotations (no getter fallback).
+ */
+private fun nameOverrideFromAnnotations(annotated: KSAnnotated): String? =
+    annotated.annotations.firstNotNullOfOrNull { it.nameOverrideOrNull() }
+
+/**
+ * Extracts a description from an annotated element's own annotations (no getter fallback).
+ */
+private fun descriptionFromAnnotations(annotated: KSAnnotated): String? =
+    annotated.annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
 
 /**
  * Extracts a name override from an annotated element's annotations.
@@ -14,8 +27,19 @@ import me.kpavlov.kt.schema.generator.core.ir.TypeRef
  * @param annotated The annotated element to inspect
  * @return The override name if found, or null if no name-override annotation is present
  */
-internal fun extractNameOverride(annotated: KSAnnotated): String? =
-    annotated.annotations.firstNotNullOfOrNull { it.nameOverrideOrNull() }
+internal fun extractNameOverride(annotated: KSAnnotated): String? = nameOverrideFromAnnotations(annotated)
+
+/**
+ * Extracts a name override from a property's own annotations or its getter's annotations.
+ *
+ * Covers `@get:` use-site targets (e.g. `@get:JsonProperty("name")`), the idiomatic
+ * Jackson-Kotlin placement for renamed properties, mirroring [isIgnoredForSchema].
+ *
+ * @param property The property to inspect
+ * @return The override name if found, or null if no name-override annotation is present
+ */
+internal fun extractNameOverride(property: KSPropertyDeclaration): String? =
+    nameOverrideFromAnnotations(property) ?: property.getter?.let(::nameOverrideFromAnnotations)
 
 /**
  * Extracts description from annotations with KDoc fallback.
@@ -31,9 +55,7 @@ internal fun extractNameOverride(annotated: KSAnnotated): String? =
 internal fun extractDescription(
     annotated: KSAnnotated,
     kdocFallback: () -> String?,
-): String? =
-    annotated.annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
-        ?: kdocFallback()
+): String? = descriptionFromAnnotations(annotated) ?: kdocFallback()
 
 /**
  * Extracts description for a property or parameter with multiple fallback sources.
@@ -57,11 +79,32 @@ internal fun extractPropertyDescription(
     kdocTagName: String,
     elementKdocFallback: () -> String?,
 ): String? =
-    // 1. Try annotations first
-    annotated.annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
-        // 2. Fall back to property's own KDoc
+    descriptionFromAnnotations(annotated)
         ?: elementKdocFallback()
-        // 3. Finally, try parent KDoc tag
+        ?: extractTagDescriptionFromKdoc(parentKdoc, kdocTagName, propertyName)
+
+/**
+ * Extracts description for a property, also checking its getter's annotations.
+ *
+ * Covers `@get:` use-site targets (e.g. `@get:JsonPropertyDescription("...")`),
+ * mirroring the getter fallback in [extractNameOverride].
+ *
+ * @param annotated The property to inspect
+ * @param propertyName The name of the property (used for parent KDoc lookup)
+ * @param parentKdoc The parent's KDoc string (class KDoc for the `@property` tag)
+ * @param kdocTagName The tag name to search in parent KDoc ("property")
+ * @param elementKdocFallback Lazy KDoc description provider for the element itself
+ * @return Description string or null if not found in any source
+ */
+internal fun extractPropertyDescription(
+    annotated: KSPropertyDeclaration,
+    propertyName: String,
+    parentKdoc: String?,
+    kdocTagName: String,
+    elementKdocFallback: () -> String?,
+): String? =
+    (descriptionFromAnnotations(annotated) ?: annotated.getter?.let(::descriptionFromAnnotations))
+        ?: elementKdocFallback()
         ?: extractTagDescriptionFromKdoc(parentKdoc, kdocTagName, propertyName)
 
 /**
@@ -72,20 +115,25 @@ internal fun extractPropertyDescription(
  *
  * Resolution chain:
  * 1. Annotations on the parameter (e.g., @Description)
- * 2. Class KDoc @param tag
- * 3. Class KDoc @property tag
+ * 2. The corresponding property's own annotations, then its getter's (e.g. `@get:JsonPropertyDescription`)
+ * 3. Class KDoc @param tag
+ * 4. Class KDoc @property tag
  *
  * @param param The constructor parameter
  * @param paramName The parameter name
  * @param classKdoc The class KDoc string
+ * @param property The property corresponding to this parameter, if any, used for the getter fallback
  * @return Description string or null if not found in any source
  */
 internal fun extractConstructorParamDescription(
     param: KSValueParameter,
     paramName: String,
     classKdoc: String?,
+    property: KSPropertyDeclaration? = null,
 ): String? =
-    param.annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
+    descriptionFromAnnotations(param)
+        ?: property?.let(::descriptionFromAnnotations)
+        ?: property?.getter?.let(::descriptionFromAnnotations)
         ?: extractTagDescriptionFromKdoc(classKdoc, "param", paramName)
         ?: extractTagDescriptionFromKdoc(classKdoc, "property", paramName)
 

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/ignore.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/ignore.kt
@@ -1,6 +1,7 @@
 package me.kpavlov.kt.schema.ksp.ir
 
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import me.kpavlov.kt.schema.generator.core.ir.Introspections
 
 /**
@@ -21,3 +22,14 @@ internal fun KSAnnotated.isSchemaIgnored(): Boolean =
         val qualifiedName = declaration.qualifiedName?.asString()
         Introspections.isIgnoreAnnotation(simpleName, qualifiedName)
     }
+
+/**
+ * Checks whether the property or its getter carries a recognized ignore annotation.
+ *
+ * Covers `@get:` use-site targets (e.g. `@get:JsonIgnore`), the idiomatic
+ * Jackson-Kotlin placement for ignored properties.
+ *
+ * @return `true` if the property or its getter is recognized as an ignore marker
+ */
+internal fun KSPropertyDeclaration.isIgnoredForSchema(): Boolean =
+    isSchemaIgnored() || getter?.isSchemaIgnored() == true


### PR DESCRIPTION
## Description

Add default Jackson support for `JsonProperty`, `JsonTypeName`, and `JsonIgnore`. APT, reflection, and KSP introspection now resolve Jackson names and exclude ignored properties. Reflection collects annotations from parameters, properties, getters, and backing fields. Tests cover renamed fields, required fields, ignored fields, and polymorphic subtype schemas. Documentation lists the new defaults.

### New Features

- Added support for Jackson property-name overrides using `JsonProperty`.
- Added support for Jackson polymorphic type names using `JsonTypeName`.
- Added support for excluding properties with `JsonIgnore`.
- Applied annotation handling consistently across reflection, annotation processing, and symbol processing.

### Fixes

- fix: honor `@get:` use-site targets for Jackson annotations on properties `@get:JsonProperty`, `@get:JsonPropertyDescription` and `@get:JsonIgnore` were inconsistently recognized across backends: the KSP name-override/description lookups and the reflection backend's inherited-sealed-parent and singleton object property checks only inspected the property itself, missing annotations placed on the getter. 
- Also removes a fragile self-referencing KSP overload that depended on an easy-to-remove upcast, and tightens the APT vararg helpers to take List<Element> instead of spreading arrays.

### Documentation

- Updated configuration and README documentation to describe the new Jackson annotation support.

**Related Issues:** #63

