### PR TITLE
fix: apply Jackson annotations to inherited and singleton properties

### DIFF
--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocument.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocument.kt
@@ -1,0 +1,17 @@
+package me.kpavlov.kt.schema.integration.type
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.kpavlov.kt.schema.Schema
+
+@Schema
+sealed class JacksonDocument {
+    @get:JsonProperty("document_id")
+    abstract val id: String
+}
+
+@Schema
+class JacksonReport(
+    val body: String,
+) : JacksonDocument() {
+    override val id: String = "r-1"
+}

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocument.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocument.kt
@@ -15,3 +15,27 @@ class JacksonReport(
 ) : JacksonDocument() {
     override val id: String = "r-1"
 }
+
+@Schema
+sealed interface JacksonMemo {
+    val id: String
+}
+
+@Schema
+class JacksonNote(
+    val body: String,
+) : JacksonMemo {
+    @get:JsonProperty("memo_id")
+    override val id: String = "n-1"
+}
+
+@Schema
+sealed class JacksonRecord {
+    abstract val id: String
+}
+
+@Schema
+data class JacksonEntry(
+    @get:JsonProperty("entry_id") override val id: String,
+    val label: String,
+) : JacksonRecord()

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocumentSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocumentSchemaTest.kt
@@ -31,4 +31,60 @@ class JacksonDocumentSchemaTest {
             }
             """.trimIndent()
     }
+
+    @Test
+    fun `honors Jackson name override declared only on the child override`() {
+        val schema = JacksonNote::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.integration.type.JacksonNote",
+              "type": "object",
+              "properties": {
+                "body": {
+                  "type": "string"
+                },
+                "memo_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "body",
+                "memo_id"
+              ],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `does not duplicate a constructor-overridden sealed property under its raw name`() {
+        val schema = JacksonEntry::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.integration.type.JacksonEntry",
+              "type": "object",
+              "properties": {
+                "entry_id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "entry_id",
+                "label"
+              ],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
 }

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocumentSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDocumentSchemaTest.kt
@@ -1,0 +1,34 @@
+package me.kpavlov.kt.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+class JacksonDocumentSchemaTest {
+    @Test
+    fun `inherited sealed property honors Jackson name override`() {
+        val schema = JacksonReport::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.integration.type.JacksonReport",
+              "type": "object",
+              "properties": {
+                "body": {
+                  "type": "string"
+                },
+                "document_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "body",
+                "document_id"
+              ],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+}

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -343,16 +343,22 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             // Find the property in the current class (inherited)
             val property = findPropertyByName(klass, propertyName)
 
-            if (property != null && !isSchemaIgnored(collectPropertyAnnotations(property))) {
+            if (property != null) {
+                val annotations = collectPropertyAnnotations(property)
+                // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
+                if (isSchemaIgnored(annotations)) return@forEach
+
+                // Name override (e.g. @SerialName, @JsonProperty), else the Kotlin property name
+                val emittedName = extractNameOverride(annotations) ?: propertyName
                 val typeRef = toRef(property.returnType)
-                val description = parentPropertyDescriptions[propertyName]
+                val description = extractDescription(annotations) ?: parentPropertyDescriptions[propertyName]
 
                 // For inherited properties, try to get the fixed value from the instance
                 val fixedValue = defaultValues[propertyName]
 
                 properties +=
                     Property(
-                        name = propertyName,
+                        name = emittedName,
                         type = typeRef,
                         description = description,
                         hasDefaultValue = fixedValue != null,
@@ -361,8 +367,9 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                     )
 
                 // Inherited properties with fixed values are required
-                requiredProperties += propertyName
+                requiredProperties += emittedName
                 processedProperties += propertyName
+                processedProperties += emittedName
             }
         }
 
@@ -372,20 +379,26 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 .filterIsInstance<KProperty<*>>()
                 .filter { it.visibility == KVisibility.PUBLIC }
                 .forEach { prop ->
-                    if (prop.name !in processedProperties && !isSchemaIgnored(collectPropertyAnnotations(prop))) {
-                        val fixedValue = defaultValues[prop.name]
-                        properties +=
-                            Property(
-                                name = prop.name,
-                                type = toRef(prop.returnType),
-                                description = extractDescription(prop.annotations),
-                                hasDefaultValue = fixedValue != null,
-                                defaultValue = fixedValue,
-                                isConstant = fixedValue != null,
-                            )
-                        requiredProperties += prop.name
-                        processedProperties += prop.name
-                    }
+                    if (prop.name in processedProperties) return@forEach
+                    val annotations = collectPropertyAnnotations(prop)
+                    // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
+                    if (isSchemaIgnored(annotations)) return@forEach
+
+                    // Name override (e.g. @SerialName, @JsonProperty), else the Kotlin property name
+                    val emittedName = extractNameOverride(annotations) ?: prop.name
+                    val fixedValue = defaultValues[prop.name]
+                    properties +=
+                        Property(
+                            name = emittedName,
+                            type = toRef(prop.returnType),
+                            description = extractDescription(annotations),
+                            hasDefaultValue = fixedValue != null,
+                            defaultValue = fixedValue,
+                            isConstant = fixedValue != null,
+                        )
+                    requiredProperties += emittedName
+                    processedProperties += prop.name
+                    processedProperties += emittedName
                 }
         }
 

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -296,18 +296,20 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 .mapNotNull { it.classifier as? KClass<*> }
                 .filter { it.isSealed }
 
-        // Build a map of parent property descriptions and properties
+        // Build a map of parent property descriptions, name overrides and properties
         val parentPropertyDescriptions = mutableMapOf<String, String>()
+        val parentPropertyNameOverrides = mutableMapOf<String, String>()
         val parentProperties = mutableSetOf<String>()
         sealedParents.forEach { parent ->
             parent.members
                 .filterIsInstance<KProperty<*>>()
                 .forEach { prop ->
                     parentProperties.add(prop.name)
-                    val desc = extractDescription(prop.annotations)
-                    if (desc != null) {
-                        parentPropertyDescriptions[prop.name] = desc
-                    }
+                    // Use the full annotation set (incl. `@get:`-targeted) so idiomatic Jackson
+                    // placements like `@get:JsonProperty` on the parent are recognized too.
+                    val parentAnnotations = collectPropertyAnnotations(prop)
+                    extractDescription(parentAnnotations)?.let { parentPropertyDescriptions[prop.name] = it }
+                    extractNameOverride(parentAnnotations)?.let { parentPropertyNameOverrides[prop.name] = it }
                 }
         }
 
@@ -319,6 +321,12 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
 
         // Track which properties were processed from constructor
         val processedProperties = constructorProperties.map { it.name }.toMutableSet()
+
+        // Original (pre-rename) constructor parameter names, used to detect sealed-parent
+        // properties already satisfied via a renamed constructor override (see below) —
+        // `processedProperties` above holds the emitted/renamed names, not the declaration names.
+        val constructorParameterNames =
+            findPrimaryConstructor(klass)?.parameters?.mapNotNull { it.name }?.toSet().orEmpty()
 
         // If there are sealed parents, update descriptions to inherit from parent if needed
         if (sealedParents.isNotEmpty()) {
@@ -338,39 +346,23 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
         requiredProperties += constructorRequired
 
         // Add inherited properties from sealed parents that weren't in the constructor
-        val inheritedPropertyNames = parentProperties - processedProperties
+        val inheritedPropertyNames = parentProperties - constructorParameterNames
         inheritedPropertyNames.forEach { propertyName ->
             // Find the property in the current class (inherited)
-            val property = findPropertyByName(klass, propertyName)
+            val property = findPropertyByName(klass, propertyName) ?: return@forEach
+            val extra =
+                buildExtraProperty(
+                    property = property,
+                    defaultValues = defaultValues,
+                    fallbackDescription = parentPropertyDescriptions[propertyName],
+                    fallbackNameOverride = parentPropertyNameOverrides[propertyName],
+                ) ?: return@forEach
 
-            if (property != null) {
-                val annotations = collectPropertyAnnotations(property)
-                // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
-                if (isSchemaIgnored(annotations)) return@forEach
-
-                // Name override (e.g. @SerialName, @JsonProperty), else the Kotlin property name
-                val emittedName = extractNameOverride(annotations) ?: propertyName
-                val typeRef = toRef(property.returnType)
-                val description = extractDescription(annotations) ?: parentPropertyDescriptions[propertyName]
-
-                // For inherited properties, try to get the fixed value from the instance
-                val fixedValue = defaultValues[propertyName]
-
-                properties +=
-                    Property(
-                        name = emittedName,
-                        type = typeRef,
-                        description = description,
-                        hasDefaultValue = fixedValue != null,
-                        defaultValue = fixedValue,
-                        isConstant = fixedValue != null,
-                    )
-
-                // Inherited properties with fixed values are required
-                requiredProperties += emittedName
-                processedProperties += propertyName
-                processedProperties += emittedName
-            }
+            properties += extra
+            // Inherited properties with fixed values are required
+            requiredProperties += extra.name
+            processedProperties += propertyName
+            processedProperties += extra.name
         }
 
         // Add public properties for objects (singletons) that weren't in the constructor or from parents
@@ -380,25 +372,12 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 .filter { it.visibility == KVisibility.PUBLIC }
                 .forEach { prop ->
                     if (prop.name in processedProperties) return@forEach
-                    val annotations = collectPropertyAnnotations(prop)
-                    // Skip properties marked with an ignore annotation (e.g. @JsonIgnore)
-                    if (isSchemaIgnored(annotations)) return@forEach
+                    val extra = buildExtraProperty(prop, defaultValues) ?: return@forEach
 
-                    // Name override (e.g. @SerialName, @JsonProperty), else the Kotlin property name
-                    val emittedName = extractNameOverride(annotations) ?: prop.name
-                    val fixedValue = defaultValues[prop.name]
-                    properties +=
-                        Property(
-                            name = emittedName,
-                            type = toRef(prop.returnType),
-                            description = extractDescription(annotations),
-                            hasDefaultValue = fixedValue != null,
-                            defaultValue = fixedValue,
-                            isConstant = fixedValue != null,
-                        )
-                    requiredProperties += emittedName
+                    properties += extra
+                    requiredProperties += extra.name
                     processedProperties += prop.name
-                    processedProperties += emittedName
+                    processedProperties += extra.name
                 }
         }
 
@@ -408,6 +387,37 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             properties = properties,
             required = requiredProperties,
             description = extractDescription(klass.java.annotations.toList()),
+        )
+    }
+
+    /**
+     * Builds a [Property] for a property discovered outside the primary constructor — either
+     * inherited from a sealed parent or declared on a singleton object. Shared by both call
+     * sites in [createObjectNode] so ignore/name-override/description resolution stays in sync.
+     *
+     * @param fallbackDescription description to use when [property]'s own annotations have none
+     *   (e.g. inherited from the sealed parent's declaration)
+     * @param fallbackNameOverride name override to use when [property]'s own annotations have
+     *   none (e.g. declared only on the sealed parent's declaration)
+     * @return the built [Property], or null if [property] is annotated as ignored
+     */
+    private fun buildExtraProperty(
+        property: KProperty<*>,
+        defaultValues: Map<String, Any?>,
+        fallbackDescription: String? = null,
+        fallbackNameOverride: String? = null,
+    ): Property? {
+        val annotations = collectPropertyAnnotations(property)
+        if (isSchemaIgnored(annotations)) return null
+
+        val fixedValue = defaultValues[property.name]
+        return Property(
+            name = extractNameOverride(annotations) ?: fallbackNameOverride ?: property.name,
+            type = toRef(property.returnType),
+            description = extractDescription(annotations) ?: fallbackDescription,
+            hasDefaultValue = fixedValue != null,
+            defaultValue = fixedValue,
+            isConstant = fixedValue != null,
         )
     }
 

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorJacksonTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorJacksonTest.kt
@@ -1,0 +1,205 @@
+package me.kpavlov.kt.schema.generator.reflect
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonTypeName
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
+import me.kpavlov.kt.schema.generator.core.ir.PolymorphicNode
+import me.kpavlov.kt.schema.generator.core.ir.TypeRef
+import kotlin.test.Test
+
+class ReflectionIntrospectorJacksonTest {
+    @Suppress("unused")
+    data class JacksonAnnotatedUser(
+        @param:JsonProperty("user_name") val userName: String,
+        @param:JsonProperty("email_address") val emailAddress: String = "n/a",
+        @field:JsonIgnore val password: String = "secret",
+    )
+
+    @Suppress("unused")
+    sealed interface JacksonVehicle {
+        @JsonTypeName("car")
+        data class Car(val doors: Int) : JacksonVehicle
+
+        @JsonTypeName("truck")
+        data class Truck(val payload: Double) : JacksonVehicle
+    }
+
+    @Suppress("unused")
+    sealed class SealedWithHiddenParentProperty {
+        @get:JsonIgnore
+        val internalId: String = "hidden-parent"
+
+        data class Variant(val visible: Int) : SealedWithHiddenParentProperty()
+    }
+
+    @Suppress("unused")
+    object SingletonWithHiddenProperty {
+        const val visible: Int = 1
+
+        @get:JsonIgnore
+        val internalToken: String = "hidden-singleton"
+    }
+
+    @Suppress("unused")
+    data class JacksonGetterAnnotatedUser(
+        @get:JsonProperty("user_login") val userName: String,
+        @get:JsonProperty("email_address")
+        @get:JsonPropertyDescription("The user's email address") val emailAddress: String = "n/a",
+        @get:JsonIgnore val sessionToken: String = "token",
+    )
+
+    @Suppress("unused")
+    sealed interface JacksonDocument {
+        val id: String
+    }
+
+    @Suppress("unused")
+    class JacksonReport(
+        val body: String,
+    ) : JacksonDocument {
+        @get:JsonProperty("document_id")
+        @get:JsonPropertyDescription("The document identifier")
+        override val id: String = "r-1"
+    }
+
+    @Suppress("unused")
+    sealed interface JacksonMemo {
+        @get:JsonProperty("memo_id")
+        val id: String
+    }
+
+    @Suppress("unused")
+    class JacksonNote(
+        val body: String,
+    ) : JacksonMemo {
+        override val id: String = "n-1"
+    }
+
+    @Suppress("unused", "AbstractClassCanBeInterface")
+    sealed class JacksonRecord {
+        abstract val id: String
+    }
+
+    @Suppress("unused")
+    data class JacksonEntry(
+        @get:JsonProperty("entry_id") override val id: String,
+        val label: String,
+    ) : JacksonRecord()
+
+    private val introspector = ReflectionClassIntrospector
+
+    @Test
+    fun `honors Jackson @JsonProperty name override in properties and required`() {
+        val graph = introspector.introspect(JacksonAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("user_name", "email_address")
+        node.required shouldBe setOf("user_name")
+    }
+
+    @Test
+    fun `excludes properties annotated with Jackson @JsonIgnore`() {
+        val graph = introspector.introspect(JacksonAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "password"
+        node.required shouldNotContain "password"
+    }
+
+    @Test
+    fun `honors Jackson @JsonTypeName on sealed subtypes in defs and discriminator`() {
+        val graph = introspector.introspect(JacksonVehicle::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[root.id].shouldBeInstanceOf<PolymorphicNode>()
+
+        val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
+        subtypeIds.shouldContainExactlyInAnyOrder(setOf("car", "truck"))
+
+        polyNode.discriminator.mapping?.keys shouldBe setOf("car", "truck")
+    }
+
+    @Test
+    fun `honors getter-targeted Jackson name override description and ignore`() {
+        val graph = introspector.introspect(JacksonGetterAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("user_login", "email_address")
+        node.properties.associateBy { it.name }.getValue("email_address").description shouldBe
+            "The user's email address"
+        node.required shouldBe setOf("user_login")
+        node.properties.map { it.name } shouldNotContain "sessionToken"
+    }
+
+    @Test
+    fun `applies Jackson annotations to inherited sealed properties`() {
+        val graph = introspector.introspect(JacksonReport::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("body", "document_id")
+        node.properties.associateBy { it.name }.getValue("document_id").apply {
+            description shouldBe "The document identifier"
+            hasDefaultValue shouldBe true
+        }
+        node.required shouldBe setOf("body", "document_id")
+    }
+
+    @Test
+    fun `honors Jackson name override declared only on the sealed parent property`() {
+        val graph = introspector.introspect(JacksonNote::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("body", "memo_id")
+        node.required shouldBe setOf("body", "memo_id")
+    }
+
+    @Test
+    fun `does not duplicate a constructor-overridden sealed property under its raw name`() {
+        val graph = introspector.introspect(JacksonEntry::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("entry_id", "label")
+        node.properties.map { it.name } shouldNotContain "id"
+        node.required shouldBe setOf("entry_id", "label")
+    }
+
+    @Test
+    fun `excludes sealed-parent inherited property annotated with @get JsonIgnore`() {
+        val graph = introspector.introspect(SealedWithHiddenParentProperty.Variant::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "internalId"
+        node.required shouldNotContain "internalId"
+    }
+
+    @Test
+    fun `excludes singleton object property annotated with @get JsonIgnore`() {
+        val graph = introspector.introspect(SingletonWithHiddenProperty::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldNotContain "internalToken"
+        node.required shouldNotContain "internalToken"
+    }
+}

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -1,11 +1,6 @@
 package me.kpavlov.kt.schema.generator.reflect
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonPropertyDescription
-import com.fasterxml.jackson.annotation.JsonTypeName
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -86,60 +81,6 @@ class ReflectionIntrospectorTest {
         val items: List<*>,
         val mapping: Map<*, *>,
     )
-
-    @Suppress("unused")
-    data class JacksonAnnotatedUser(
-        @param:JsonProperty("user_name") val userName: String,
-        @param:JsonProperty("email_address") val emailAddress: String = "n/a",
-        @field:JsonIgnore val password: String = "secret",
-    )
-
-    @Suppress("unused")
-    sealed interface JacksonVehicle {
-        @JsonTypeName("car")
-        data class Car(val doors: Int) : JacksonVehicle
-
-        @JsonTypeName("truck")
-        data class Truck(val payload: Double) : JacksonVehicle
-    }
-
-    @Suppress("unused")
-    sealed class SealedWithHiddenParentProperty {
-        @get:JsonIgnore
-        val internalId: String = "hidden-parent"
-
-        data class Variant(val visible: Int) : SealedWithHiddenParentProperty()
-    }
-
-    @Suppress("unused")
-    object SingletonWithHiddenProperty {
-        const val visible: Int = 1
-
-        @get:JsonIgnore
-        val internalToken: String = "hidden-singleton"
-    }
-
-    @Suppress("unused")
-    data class JacksonGetterAnnotatedUser(
-        @get:JsonProperty("user_login") val userName: String,
-        @get:JsonProperty("email_address")
-        @get:JsonPropertyDescription("The user's email address") val emailAddress: String = "n/a",
-        @get:JsonIgnore val sessionToken: String = "token",
-    )
-
-    @Suppress("unused")
-    sealed interface JacksonDocument {
-        val id: String
-    }
-
-    @Suppress("unused")
-    class JacksonReport(
-        val body: String,
-    ) : JacksonDocument {
-        @get:JsonProperty("document_id")
-        @get:JsonPropertyDescription("The document identifier")
-        override val id: String = "r-1"
-    }
 
     private val introspector = ReflectionClassIntrospector
 
@@ -381,91 +322,5 @@ class ReflectionIntrospectorTest {
                 }
             }
         }
-    }
-
-    @Test
-    fun `honors Jackson @JsonProperty name override in properties and required`() {
-        val graph = introspector.introspect(JacksonAnnotatedUser::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldBe listOf("user_name", "email_address")
-        node.required shouldBe setOf("user_name")
-    }
-
-    @Test
-    fun `excludes properties annotated with Jackson @JsonIgnore`() {
-        val graph = introspector.introspect(JacksonAnnotatedUser::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldNotContain "password"
-        node.required shouldNotContain "password"
-    }
-
-    @Test
-    fun `honors Jackson @JsonTypeName on sealed subtypes in defs and discriminator`() {
-        val graph = introspector.introspect(JacksonVehicle::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val polyNode = graph.nodes[root.id].shouldBeInstanceOf<PolymorphicNode>()
-
-        val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
-        subtypeIds.shouldContainExactlyInAnyOrder(setOf("car", "truck"))
-
-        polyNode.discriminator.mapping?.keys shouldBe setOf("car", "truck")
-    }
-
-    @Test
-    fun `honors getter-targeted Jackson name override description and ignore`() {
-        val graph = introspector.introspect(JacksonGetterAnnotatedUser::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldBe listOf("user_login", "email_address")
-        node.properties.associateBy { it.name }.getValue("email_address").description shouldBe
-            "The user's email address"
-        node.required shouldBe setOf("user_login")
-        node.properties.map { it.name } shouldNotContain "sessionToken"
-    }
-
-    @Test
-    fun `applies Jackson annotations to inherited sealed properties`() {
-        val graph = introspector.introspect(JacksonReport::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldBe listOf("body", "document_id")
-        node.properties.associateBy { it.name }.getValue("document_id").apply {
-            description shouldBe "The document identifier"
-            hasDefaultValue shouldBe true
-        }
-        node.required shouldBe setOf("body", "document_id")
-    }
-
-    @Test
-    fun `excludes sealed-parent inherited property annotated with @get JsonIgnore`() {
-        val graph = introspector.introspect(SealedWithHiddenParentProperty.Variant::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldNotContain "internalId"
-        node.required shouldNotContain "internalId"
-    }
-
-    @Test
-    fun `excludes singleton object property annotated with @get JsonIgnore`() {
-        val graph = introspector.introspect(SingletonWithHiddenProperty::class)
-
-        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
-        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
-
-        node.properties.map { it.name } shouldNotContain "internalToken"
-        node.required shouldNotContain "internalToken"
     }
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -2,6 +2,7 @@ package me.kpavlov.kt.schema.generator.reflect
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.annotation.JsonTypeName
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
@@ -116,6 +117,28 @@ class ReflectionIntrospectorTest {
 
         @get:JsonIgnore
         val internalToken: String = "hidden-singleton"
+    }
+
+    @Suppress("unused")
+    data class JacksonGetterAnnotatedUser(
+        @get:JsonProperty("user_login") val userName: String,
+        @get:JsonProperty("email_address")
+        @get:JsonPropertyDescription("The user's email address") val emailAddress: String = "n/a",
+        @get:JsonIgnore val sessionToken: String = "token",
+    )
+
+    @Suppress("unused")
+    sealed interface JacksonDocument {
+        val id: String
+    }
+
+    @Suppress("unused")
+    class JacksonReport(
+        val body: String,
+    ) : JacksonDocument {
+        @get:JsonProperty("document_id")
+        @get:JsonPropertyDescription("The document identifier")
+        override val id: String = "r-1"
     }
 
     private val introspector = ReflectionClassIntrospector
@@ -393,6 +416,35 @@ class ReflectionIntrospectorTest {
         subtypeIds.shouldContainExactlyInAnyOrder(setOf("car", "truck"))
 
         polyNode.discriminator.mapping?.keys shouldBe setOf("car", "truck")
+    }
+
+    @Test
+    fun `honors getter-targeted Jackson name override description and ignore`() {
+        val graph = introspector.introspect(JacksonGetterAnnotatedUser::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("user_login", "email_address")
+        node.properties.associateBy { it.name }.getValue("email_address").description shouldBe
+            "The user's email address"
+        node.required shouldBe setOf("user_login")
+        node.properties.map { it.name } shouldNotContain "sessionToken"
+    }
+
+    @Test
+    fun `applies Jackson annotations to inherited sealed properties`() {
+        val graph = introspector.introspect(JacksonReport::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.map { it.name } shouldBe listOf("body", "document_id")
+        node.properties.associateBy { it.name }.getValue("document_id").apply {
+            description shouldBe "The document identifier"
+            hasDefaultValue shouldBe true
+        }
+        node.required shouldBe setOf("body", "document_id")
     }
 
     @Test

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -370,12 +370,13 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
 
         sealedParents.forEach { parent ->
             parent.getDeclaredProperties().filter { it.isPublic() && !it.isIgnoredForSchema() }.forEach { prop ->
-                val name = prop.simpleName.asString()
-                if (name !in processedProperties) {
+                val kotlinName = prop.simpleName.asString()
+                if (kotlinName !in processedProperties) {
+                    val name = extractNameOverride(prop) ?: kotlinName
                     val description =
                         extractPropertyDescription(
                             annotated = prop,
-                            propertyName = name,
+                            propertyName = kotlinName,
                             parentKdoc = parent.docString,
                             kdocTagName = "property",
                             elementKdocFallback = { prop.descriptionFromKdoc() },

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -285,7 +285,10 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
             val props = ArrayList<Property>()
             val required = LinkedHashSet<String>()
 
-            val processedProperties = HashSet<String>()
+            // Original (pre-rename) Kotlin declaration names already handled directly by this
+            // class — NOT the emitted/renamed names, so a sealed-parent property satisfied via a
+            // renamed constructor override isn't mistaken for unprocessed and re-added below.
+            val processedKotlinNames = HashSet<String>()
 
             /**
              * Helper to add a property and track whether it's required.
@@ -293,6 +296,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
              * Properties without default values are automatically added to the required set.
              */
             fun addProperty(
+                kotlinName: String,
                 name: String,
                 type: KSType,
                 description: String?,
@@ -301,11 +305,11 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
             ) {
                 if (!hasDefaultValue || isConstant) required += name
                 props += createProperty(name, toRef(type), description, hasDefaultValue, isConstant)
-                processedProperties += name
+                processedKotlinNames += kotlinName
             }
 
             extractConstructorOrProperties(decl, ::addProperty)
-            extractInheritedSealedProperties(decl, processedProperties, ::addProperty)
+            extractInheritedSealedProperties(decl, processedKotlinNames, ::addProperty)
 
             val nameOverride = extractNameOverride(decl)
             ObjectNode(
@@ -321,7 +325,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
 
     private fun extractConstructorOrProperties(
         decl: KSClassDeclaration,
-        addProperty: (String, KSType, String?, Boolean) -> Unit,
+        addProperty: (String, String, KSType, String?, Boolean) -> Unit,
     ) {
         val declaredProperties = decl.getDeclaredProperties().associateBy { it.simpleName.asString() }
         // Prefer primary constructor parameters for data classes; fall back to public properties
@@ -335,7 +339,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 val propertyName =
                     extractNameOverride(p) ?: property?.let { extractNameOverride(it) } ?: kotlinName
                 val description = extractConstructorParamDescription(p, kotlinName, decl.docString, property)
-                addProperty(propertyName, p.type.resolve(), description, p.hasDefault)
+                addProperty(kotlinName, propertyName, p.type.resolve(), description, p.hasDefault)
             }
         } else {
             declaredProperties.values
@@ -351,15 +355,15 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                             kdocTagName = "property",
                             elementKdocFallback = { prop.descriptionFromKdoc() },
                         )
-                    addProperty(propertyName, prop.type.resolve(), description, false)
+                    addProperty(kotlinName, propertyName, prop.type.resolve(), description, false)
                 }
         }
     }
 
     private fun extractInheritedSealedProperties(
         decl: KSClassDeclaration,
-        processedProperties: Set<String>,
-        addProperty: (String, KSType, String?, Boolean, Boolean) -> Unit,
+        processedKotlinNames: Set<String>,
+        addProperty: (String, String, KSType, String?, Boolean, Boolean) -> Unit,
     ) {
         // Add inherited properties from sealed parents that weren't in the constructor
         val sealedParents =
@@ -368,22 +372,37 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 .filter { it.modifiers.contains(Modifier.SEALED) }
                 .toList()
 
+        // The child's own declared properties, so an override that re-declares the annotation
+        // (e.g. `@get:JsonProperty` placed on the subclass's `override val`) takes precedence
+        // over the parent's — mirroring how the reflection-based introspector resolves overrides.
+        val childDeclaredProperties = decl.getDeclaredProperties().associateBy { it.simpleName.asString() }
+
         sealedParents.forEach { parent ->
-            parent.getDeclaredProperties().filter { it.isPublic() && !it.isIgnoredForSchema() }.forEach { prop ->
-                val kotlinName = prop.simpleName.asString()
-                if (kotlinName !in processedProperties) {
-                    val name = extractNameOverride(prop) ?: kotlinName
+            parent.getDeclaredProperties().filter { it.isPublic() && !it.isIgnoredForSchema() }.forEach { parentProp ->
+                val kotlinName = parentProp.simpleName.asString()
+                if (kotlinName !in processedKotlinNames) {
+                    val overridingProp = childDeclaredProperties[kotlinName]
+                    val effectiveProp = overridingProp ?: parentProp
+
+                    // Prefer the child override's own name override (covers a re-declared
+                    // `@get:JsonProperty`), falling back to the parent's — mirroring how the
+                    // reflection-based introspector resolves overrides.
+                    val name =
+                        overridingProp?.let { extractNameOverride(it) }
+                            ?: extractNameOverride(parentProp)
+                            ?: kotlinName
                     val description =
                         extractPropertyDescription(
-                            annotated = prop,
+                            annotated = effectiveProp,
                             propertyName = kotlinName,
                             parentKdoc = parent.docString,
                             kdocTagName = "property",
-                            elementKdocFallback = { prop.descriptionFromKdoc() },
+                            elementKdocFallback = { effectiveProp.descriptionFromKdoc() },
                         )
                     addProperty(
+                        kotlinName,
                         name,
-                        prop.type.resolve(),
+                        parentProp.type.resolve(),
                         description,
                         true, // Fixed value in the subclass
                         false, // KSP cannot get the value


### PR DESCRIPTION
## Summary

Jackson annotations now apply to inherited and singleton properties during reflection-based schema generation. The generator handles name overrides, descriptions, ignored properties, and required-property tracking. KSP handling emits overridden names for inherited sealed-parent properties while retaining Kotlin names for duplicate detection. New unit and integration tests cover these cases with Jackson document models.

## New Features

- Added support for Jackson annotations on inherited and singleton properties during JSON schema generation.
- Supports custom property names, descriptions, ignored properties, and fixed identifiers.

### Bug Fixes

- Corrected handling of renamed inherited properties while preserving accurate duplicate detection.
- Ensured required fields use their emitted schema names.

### Tests
- Added coverage for Jackson property renaming, descriptions, ignored fields, inherited properties, and required-field behavior.


