### PR TITLE
chore: 0.8.0 and examples

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -17,8 +17,10 @@ dependencies {
     implementation(libs.kotest.assertions.json)
 
     dokka(project(":kt-schema-annotations"))
-    "dokka"(project(":kt-schema-generator-core"))
-    "dokka"(project(":kt-schema-generator-json"))
+    dokka(project(":kt-schema-generator-core"))
+    dokka(project(":kt-schema-generator-json"))
+    dokka(project(":kt-schema-apt"))
+    dokka(project(":kt-schema-ksp"))
     dokka(project(":kt-schema-json"))
 }
 

--- a/examples/gradle-google-ksp/gradle.properties
+++ b/examples/gradle-google-ksp/gradle.properties
@@ -12,4 +12,4 @@ name = gradle-google-ksp-example
 group=me.kpavlov.kt.schema.examples
 version=1.0-SNAPSHOT
 
-ktSchemaVersion=0.6.0
+ktSchemaVersion=0.8.0

--- a/examples/maven-ksp/pom.xml
+++ b/examples/maven-ksp/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <kotlin.version>2.3.21</kotlin.version>
         <maven.compiler.release>25</maven.compiler.release>
-        <ksp.plugin.version>0.4.5</ksp.plugin.version>
-        <kt-schema.version>0.6.0</kt-schema.version>
+        <ksp.plugin.version>0.4.6</ksp.plugin.version>
+        <kt-schema.version>0.8.0</kt-schema.version>
         <kotest.version>6.1.11</kotest.version>
         <kotlinx-serialization.version>1.10.0</kotlinx-serialization.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ ksp.useKSP2=true
 detekt.use.worker.api = true
 
 group=me.kpavlov.kt.schema
-version=0.8.0-SNAPSHOT
+version=0.8.1-SNAPSHOT
 
 versionSuffix=SNAPSHOT
 

--- a/kt-schema-apt/Module.md
+++ b/kt-schema-apt/Module.md
@@ -37,15 +37,6 @@ See [Java Annotation Processor Guide](https://github.com/kpavlov/kt-schema/blob/
 - Recognizes description/ignore/name-override annotations from Jackson, LangChain4j, Koog, etc. via the shared
   [`Introspections`][me.kpavlov.kt.schema.generator.core.ir.Introspections] config, same as KSP and reflection
 
-## Limitations
-
-- Only Java `record`s are supported as root/nested types; enums, sealed hierarchies, generics,
-  collections/maps, and ordinary classes aren't yet
-- Reference-typed record components are non-nullable/required by default; mark one nullable/optional via
-  a `@Nullable`-style annotation or a type-name glob pattern (default `*Opt`) — see
-  [Java Annotation Processor Guide](https://github.com/kpavlov/kt-schema/blob/main/docs/apt.md)
-- No `include`/`exclude`/`withSchemaObject`/`visibility`/`enabled` options (available in `kt-schema-ksp`)
-
 # Package me.kpavlov.kt.schema.apt
 
 JSR 269 annotation processor implementation.


### PR DESCRIPTION
## Description

- Updated the project to version 0.8.1-SNAPSHOT.
- Updated example configurations to use kt-schema 0.8.0.
- Updated the Maven KSP example to use KSP Maven plugin 0.4.6
- Add kt-schema-apt and kt-schema-ksp to apidocs
