### PR TITLE
feat(apt): add enum support to kt-schema-apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Quick Links:
 
 **Generation Modes:**
 
-- **Compile-time (Java APT)**: Zero runtime overhead for plain Java records — no Kotlin required in your code
+- **Compile-time (Java APT)**: Zero runtime overhead for plain Java records, classes, interfaces and enums — no Kotlin required in your code
 - **Compile-time (KSP)**: Zero runtime overhead, multiplatform, for your annotated Kotlin classes
 - **Runtime (Reflection)**: JVM-only, for any class including third-party libraries
 - **Runtime (SerialDescriptor)**: Kotlin serializable classes, including open polymorphism via `SerializersModule`
@@ -170,7 +170,7 @@ This library solves three key challenges:
 in your schema.
 
 - **[Pick Java APT](docs/apt.md)** when your code is plain Java (no Kotlin) and you want zero runtime overhead.
-Currently supports Java records only.
+Supports Java records, classes, interfaces and enums.
 
 - **[Pick Serialization-based](docs/serializable.md)** when your classes are already `@Serializable` and you need
 Multiplatform support without a build-time processor.

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Priority.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Priority.java
@@ -1,0 +1,17 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Simple test model to verify JsonTypeName/JsonProperty name overrides on a Java enum.
+ */
+@JsonTypeName("PriorityLevel")
+public enum Priority {
+    @JsonProperty("low")
+    LOW,
+    @JsonProperty("medium")
+    MEDIUM,
+    @JsonProperty("high")
+    HIGH
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Status.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Status.java
@@ -1,0 +1,11 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+
+/**
+ * Simple test model to verify Java enum schema generation.
+ */
+@JsonClassDescription("Current lifecycle status of an entity.")
+public enum Status {
+    ACTIVE, INACTIVE, PENDING
+}

--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Ticket.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Ticket.java
@@ -1,0 +1,13 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Simple test model to verify a nested enum field reference in generated schemas.
+ */
+@JsonClassDescription("A support ticket with a lifecycle status.")
+public record Ticket(
+        @JsonPropertyDescription("Unique ticket identifier") String id,
+        @JsonPropertyDescription("Current status of the ticket") Status status) {
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PrioritySchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PrioritySchemaTest.java
@@ -1,0 +1,41 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/**
+ * Verifies the kt-schema-apt processor honors JsonTypeName/JsonProperty name overrides
+ * on a Java enum, generated from the file path derived from the class's own simple name.
+ */
+class PrioritySchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Priority.json";
+
+    @Test
+    void shouldGenerateEnumSchemaWithJsonTypeNameAndJsonPropertyOverrides() throws IOException {
+        // language=json
+        assertThatJson(readGeneratedSchema()).isEqualTo("""
+                {
+                  "$id": "PriorityLevel",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "string",
+                  "enum": ["low", "medium", "high"]
+                }
+                """);
+    }
+
+    private static String readGeneratedSchema() throws IOException {
+        try (InputStream input = PrioritySchemaTest.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            if (input == null) {
+                throw new IllegalStateException("Missing generated schema resource: " + RESOURCE_PATH);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/StatusSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/StatusSchemaTest.java
@@ -1,0 +1,41 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java enum.
+ */
+class StatusSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Status.json";
+
+    @Test
+    void shouldGenerateEnumSchemaWithAllValues() throws IOException {
+        // language=json
+        assertThatJson(readGeneratedSchema()).isEqualTo("""
+                {
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Status",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "string",
+                  "enum": ["ACTIVE", "INACTIVE", "PENDING"],
+                  "description": "Current lifecycle status of an entity."
+                }
+                """);
+    }
+
+    private static String readGeneratedSchema() throws IOException {
+        try (InputStream input = StatusSchemaTest.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            if (input == null) {
+                throw new IllegalStateException("Missing generated schema resource: " + RESOURCE_PATH);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/TicketSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/TicketSchemaTest.java
@@ -1,0 +1,60 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * record referencing a nested enum field.
+ */
+class TicketSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Ticket.json";
+
+    @Test
+    void shouldGenerateSchemaWithNestedEnumRef() throws IOException {
+        // language=json
+        assertThatJson(readGeneratedSchema()).isEqualTo("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Ticket",
+                  "description": "A support ticket with a lifecycle status.",
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique ticket identifier"
+                    },
+                    "status": {
+                      "$ref": "#/$defs/me.kpavlov.kt.schema.apt.integration.type.Status",
+                      "description": "Current status of the ticket"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["id", "status"],
+                  "$defs": {
+                    "me.kpavlov.kt.schema.apt.integration.type.Status": {
+                      "type": "string",
+                      "enum": ["ACTIVE", "INACTIVE", "PENDING"],
+                      "description": "Current lifecycle status of an entity."
+                    }
+                  }
+                }
+                """);
+    }
+
+    private static String readGeneratedSchema() throws IOException {
+        try (InputStream input = TicketSchemaTest.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            if (input == null) {
+                throw new IllegalStateException("Missing generated schema resource: " + RESOURCE_PATH);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -17,7 +17,7 @@
 
 <!--- END -->
 
-Generate JSON Schema resources at compile time from plain Java records, classes and interfaces using the
+Generate JSON Schema resources at compile time from plain Java records, classes, interfaces and enums using the
 `kt-schema-apt` JSR 269 (`javax.annotation.processing`) processor — no Kotlin required in your own code.
 
 ## Setup
@@ -291,6 +291,7 @@ try (InputStream in = Person.class.getClassLoader()
 - Plain Java `class`es — non-static fields map to required properties, treated the same way as records
 - Java `interface`s — no-arg methods map to required properties, named per the JavaBeans convention
   (`getName()` → `name`, `isActive()` → `active`, and a bare `name()` accessor stays `name`)
+- Java `enum`s — emitted as `type: string` with an `enum` array listing the constants in declaration order
 - `String`, boxed and primitive numeric/boolean types
 - `Iterable`-derived collections (`List`, `Set`, `Collection`, custom subclasses) — emitted as `array` with
   `items` describing the element type
@@ -300,7 +301,7 @@ try (InputStream in = Person.class.getClassLoader()
 - Type variables: upper-bounded (`T extends Number`) resolve to their bound; unbounded (`T`) emit `{}`
 - Nested records/classes/interfaces, emitted as `$ref`/`$defs` and deduplicated, same as KSP
 
-Not yet supported: enums and sealed class hierarchies (polymorphic `oneOf` with discriminators). Processing an
+Not yet supported: sealed class hierarchies (polymorphic `oneOf` with discriminators). Processing an
 unsupported type fails the build with a descriptive error rather than emitting an incomplete schema.
 
 ### Marking a property nullable/optional

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/Priority.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/Priority.kt
@@ -1,0 +1,20 @@
+package me.kpavlov.kt.schema.integration.type
+
+import kotlinx.serialization.SerialName
+import me.kpavlov.kt.schema.Schema
+
+/**
+ * Enum class with SerialName overrides on the class and its entries.
+ */
+@SerialName("PriorityLevel")
+@Schema
+enum class Priority {
+    @SerialName("p0_critical")
+    CRITICAL,
+
+    @SerialName("p1_high")
+    HIGH,
+
+    @SerialName("p2_low")
+    LOW,
+}

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/PrioritySchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/PrioritySchemaTest.kt
@@ -1,0 +1,26 @@
+package me.kpavlov.kt.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/**
+ * Tests for Priority schema generation - SerialName overrides on an enum class and its entries.
+ */
+class PrioritySchemaTest {
+    @Test
+    fun `generates enum schema with SerialName-overridden id and values`() {
+        val schema = Priority::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$id": "PriorityLevel",
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+              "enum": ["p0_critical", "p1_high", "p2_low"],
+              "description": "Enum class with SerialName overrides on the class and its entries."
+            }
+            """.trimIndent()
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessor.kt
@@ -95,7 +95,7 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     /**
      * Discovers the types to process, mirroring the KSP processor's filtering:
      *
-     * 1. Only records, classes and interfaces are considered.
+     * 1. Only records, classes, interfaces and enums are considered.
      * 2. When [ROOT_PACKAGE_OPTION] is set, only types under that package (and its
      *    sub-packages) are considered; otherwise the whole module is scanned.
      * 3. A type is selected when it is annotated with `@Schema` or matches at least one
@@ -115,6 +115,7 @@ public class JsonSchemaProcessor : AbstractProcessor() {
         val fromRoots = roundEnv.rootElements.filterIsInstance<TypeElement>()
 
         return (annotated + fromRoots)
+            .asSequence()
             .filter { it.isSupported() }
             .filter { rootPackage == null || it.isUnderPackage(rootPackage) }
             .filter { it.isAnnotatedWithSchema() || globMatcher.matchesInclude(it.qualifiedName.toString()) }
@@ -123,10 +124,17 @@ public class JsonSchemaProcessor : AbstractProcessor() {
     }
 
     private fun TypeElement.isSupported(): Boolean =
-        kind == ElementKind.RECORD || kind == ElementKind.CLASS || kind == ElementKind.INTERFACE
+        kind == ElementKind.RECORD ||
+            kind == ElementKind.CLASS ||
+            kind == ElementKind.INTERFACE ||
+            kind == ElementKind.ENUM
 
     private fun TypeElement.isUnderPackage(rootPackage: String): Boolean {
-        val packageName = processingEnv.elementUtils.getPackageOf(this).qualifiedName.toString()
+        val packageName =
+            processingEnv.elementUtils
+                .getPackageOf(this)
+                .qualifiedName
+                .toString()
         return packageName == rootPackage || packageName.startsWith("$rootPackage.")
     }
 

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospector.kt
@@ -10,9 +10,9 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Types
 
 /**
- * Java-APT-backed schema IR introspector. Supports records, plain classes and interfaces
- * with primitive/String/boxed field types, nested references, collections, maps, arrays
- * and upper-bounded type variables; enums and sealed/polymorphic hierarchies are not yet
+ * Java-APT-backed schema IR introspector. Supports records, plain classes, interfaces and
+ * enums, with primitive/String/boxed field types, nested references, collections, maps,
+ * arrays and upper-bounded type variables; sealed/polymorphic hierarchies are not yet
  * supported.
  *
  * A fresh [AptIntrospectionContext] is created per root so `$defs` stay scoped to the

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -4,6 +4,7 @@ package me.kpavlov.kt.schema.apt.ir
 import me.kpavlov.kt.schema.generator.core.InternalSchemaGeneratorApi
 import me.kpavlov.kt.schema.generator.core.ir.AnyNode
 import me.kpavlov.kt.schema.generator.core.ir.BaseIntrospectionContext
+import me.kpavlov.kt.schema.generator.core.ir.EnumNode
 import me.kpavlov.kt.schema.generator.core.ir.Introspections
 import me.kpavlov.kt.schema.generator.core.ir.ListNode
 import me.kpavlov.kt.schema.generator.core.ir.MapNode
@@ -34,7 +35,7 @@ import javax.lang.model.util.Types
 /**
  * Introspection context for the Java annotation-processor (JSR 269) front end.
  *
- * Supports Java records, plain classes and interfaces with primitive/boxed/String fields,
+ * Supports Java records, plain classes, interfaces and enums with primitive/boxed/String fields,
  * nested references, collections (`List`/`Set`/`Collection`/`Iterable`), maps (`Map`),
  * arrays, `Object` and upper-bounded type variables. Java has no notion of nullability or
  * optionality/default values, so every property is non-nullable/required by default — except
@@ -102,11 +103,12 @@ internal class AptIntrospectionContext(
 
     private fun handleReferenceType(type: TypeMirror): TypeRef =
         handleRecord(type)
+            ?: handleEnum(type)
             ?: handleClass(type)
             ?: handleInterface(type)
             ?: error(
                 "Unsupported type for kt-schema-apt " +
-                    "(only records, classes, interfaces, primitives, String, collections, maps and arrays " +
+                    "(only records, classes, interfaces, enums, primitives, String, collections, maps and arrays " +
                     "are supported): $type",
             )
 
@@ -281,6 +283,32 @@ internal class AptIntrospectionContext(
         return TypeRef.Ref(id)
     }
 
+    private fun handleEnum(type: TypeMirror): TypeRef? {
+        val element = asTypeElement(type)
+        if (element == null || element.kind != ElementKind.ENUM) return null
+
+        val id = TypeId(element.qualifiedName.toString())
+
+        return namedRef(type, id) {
+            buildOrGet(type, id) {
+                val entries =
+                    element.enclosedElements
+                        .filterIsInstance<VariableElement>()
+                        .filter { it.kind == ElementKind.ENUM_CONSTANT }
+                        .map { constant -> nameOverrideFor(listOf(constant)) ?: constant.simpleName.toString() }
+                check(entries.isNotEmpty()) {
+                    "Enum ${element.qualifiedName} has no constants; cannot generate a JSON Schema enum"
+                }
+
+                EnumNode(
+                    name = nameOverrideFor(listOf(element)) ?: element.qualifiedName.toString(),
+                    entries = entries,
+                    description = extractDescription(element),
+                )
+            }
+        }
+    }
+
     private fun handleClass(type: TypeMirror): TypeRef? {
         val element = asTypeElement(type)
         if (element == null || element.kind != ElementKind.CLASS) return null
@@ -386,30 +414,33 @@ internal class AptIntrospectionContext(
      * complete. Registration recurses through [toRef], which deduplicates via
      * [withCycleDetection], so shared subgraphs are registered exactly once per root.
      */
-    private fun buildOrGet(
+    private fun <T : TypeNode> buildOrGet(
         type: TypeMirror,
         id: TypeId,
-        builder: () -> TypeNode,
-    ): TypeNode {
+        builder: () -> T,
+    ): T {
         nodeCache[id]?.let { cached ->
             registerRefs(cached.node)
-            return cached.node
+            // Safe: id is always element.qualifiedName, and a qualified name has exactly one
+            // ElementKind, so the same id is never built with a different T.
+            @Suppress("UNCHECKED_CAST")
+            return cached.node as T
         }
         return builder().also { nodeCache[id] = CachedNode(type, it) }
     }
 
     /**
-     * Re-registers the types referenced by [node] into the current context. The apt front
-     * end only caches object nodes, so any other cached node kind is an unsupported
-     * invariant. References are registered through inline list/map nodes as well, so a
-     * cached `List<Shared>` property still pulls `Shared` into a fresh root's `$defs`.
+     * Re-registers the types referenced by [node] into the current context. Object nodes
+     * recurse into their properties; enum nodes are leaves with nothing to re-register. Any
+     * other cached node kind is an unsupported invariant. References are registered through
+     * inline list/map nodes as well, so a cached `List<Shared>` property still pulls `Shared`
+     * into a fresh root's `$defs`.
      */
     private fun registerRefs(node: TypeNode) {
-        val objectNode =
-            node as? ObjectNode
-                ?: error("Unsupported cached node kind $node; registerRefs must handle all node kinds")
-        objectNode.properties.forEach { property ->
-            registerRefs(property.type)
+        when (node) {
+            is ObjectNode -> node.properties.forEach { property -> registerRefs(property.type) }
+            is EnumNode -> Unit
+            else -> error("Unsupported cached node kind $node; registerRefs must handle all node kinds")
         }
     }
 

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -231,6 +231,126 @@ class JsonSchemaProcessorTest {
         @TempDir tempDir: Path,
     ) {
         // language=java
+        val tagSource = """
+            package com.example;
+
+            public @interface Tag {}
+        """.trimIndent()
+
+        // language=java
+        val itemSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Item(Tag tag) {}
+        """.trimIndent()
+
+        val exception =
+            assertFailsWith<IllegalStateException> {
+                compile(listOf(tagSource, itemSource), tempDir)
+            }
+
+        assertSoftly(exception) {
+            message shouldContain "Unsupported type for kt-schema-apt"
+            message shouldContain "com.example.Tag"
+        }
+    }
+
+    @Test
+    fun `should fail the build when an enum has no constants`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public enum Empty {
+            }
+        """.trimIndent()
+
+        val exception =
+            assertFailsWith<IllegalStateException> {
+                compile(source, tempDir)
+            }
+
+        assertSoftly(exception) {
+            message shouldContain "com.example.Empty"
+            message shouldContain "no constants"
+        }
+    }
+
+    @Test
+    fun `should generate schema for annotated enum`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public enum Color {
+                RED, GREEN, BLUE
+            }
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        // language=json
+        outputDir.readSchema("com.example.Color") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Color",
+                "type": "string",
+                "enum": ["RED", "GREEN", "BLUE"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for unannotated enum via root package and include options`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            public enum Color {
+                RED, GREEN, BLUE
+            }
+        """.trimIndent()
+
+        val outputDir = compile(
+            source = source,
+            tempDir = tempDir,
+            options = listOf(
+                "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
+                "-A${JsonSchemaProcessor.INCLUDE_OPTION}=com.example.*",
+            ),
+        )
+
+        // language=json
+        outputDir.readSchema("com.example.Color") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Color",
+                "type": "string",
+                "enum": ["RED", "GREEN", "BLUE"]
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for record referencing an enum field`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
         val colorSource = """
             package com.example;
 
@@ -249,15 +369,105 @@ class JsonSchemaProcessorTest {
             public record Car(Color color) {}
         """.trimIndent()
 
-        val exception =
-            assertFailsWith<IllegalStateException> {
-                compile(listOf(colorSource, carSource), tempDir)
-            }
+        val outputDir = compile(listOf(colorSource, carSource), tempDir)
 
-        assertSoftly(exception) {
-            message shouldContain "Unsupported type for kt-schema-apt"
-            message shouldContain "com.example.Color"
-        }
+        // language=json
+        outputDir.readSchema("com.example.Car") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Car",
+                "type": "object",
+                "properties": {
+                    "color": { "$ref": "#/$defs/com.example.Color" }
+                },
+                "additionalProperties": false,
+                "required": ["color"],
+                "$defs": {
+                    "com.example.Color": {
+                        "type": "string",
+                        "enum": ["RED", "GREEN", "BLUE"]
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schemas for enum field shared by multiple roots`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val colorSource = """
+            package com.example;
+
+            public enum Color {
+                RED, GREEN, BLUE
+            }
+        """.trimIndent()
+
+        // language=java
+        val carSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Car(Color color) {}
+        """.trimIndent()
+
+        // language=java
+        val bikeSource = """
+            package com.example;
+
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Bike(Color color) {}
+        """.trimIndent()
+
+        val outputDir = compile(listOf(colorSource, carSource, bikeSource), tempDir)
+
+        // language=json
+        val expectedSchema = $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Car",
+                "type": "object",
+                "properties": {
+                    "color": { "$ref": "#/$defs/com.example.Color" }
+                },
+                "additionalProperties": false,
+                "required": ["color"],
+                "$defs": {
+                    "com.example.Color": {
+                        "type": "string",
+                        "enum": ["RED", "GREEN", "BLUE"]
+                    }
+                }
+            }
+        """.trimIndent()
+
+        outputDir.readSchema("com.example.Car") shouldEqualJson expectedSchema
+
+        // language=json
+        outputDir.readSchema("com.example.Bike") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Bike",
+                "type": "object",
+                "properties": {
+                    "color": { "$ref": "#/$defs/com.example.Color" }
+                },
+                "additionalProperties": false,
+                "required": ["color"],
+                "$defs": {
+                    "com.example.Color": {
+                        "type": "string",
+                        "enum": ["RED", "GREEN", "BLUE"]
+                    }
+                }
+            }
+        """.trimIndent()
     }
 
     @Test
@@ -1177,12 +1387,7 @@ class JsonSchemaProcessorTest {
                 ),
             ),
             Arguments.of(
-                "type is an annotated enum",
-                annotatedEnum,
-                emptyList<String>(),
-            ),
-            Arguments.of(
-                "type is an enum under root package",
+                "unannotated enum under root package without include glob",
                 plainEnum,
                 listOf(
                     "-A${JsonSchemaProcessor.ROOT_PACKAGE_OPTION}=com.example",
@@ -1220,18 +1425,6 @@ class JsonSchemaProcessorTest {
         package com.example;
 
         public record Person(String name) {}
-    """.trimIndent()
-
-    // language=java
-    private val annotatedEnum = """
-        package com.example;
-
-        import me.kpavlov.kt.schema.Schema;
-
-        @Schema
-        public enum Color {
-            RED, GREEN, BLUE
-        }
     """.trimIndent()
 
     // language=java

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import me.kpavlov.kt.schema.apt.JavaSources
 import me.kpavlov.kt.schema.generator.core.ir.AnyNode
+import me.kpavlov.kt.schema.generator.core.ir.EnumNode
 import me.kpavlov.kt.schema.generator.core.ir.ListNode
 import me.kpavlov.kt.schema.generator.core.ir.MapNode
 import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
@@ -14,6 +15,7 @@ import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
 import me.kpavlov.kt.schema.generator.core.ir.TypeGraph
 import me.kpavlov.kt.schema.generator.core.ir.TypeId
 import me.kpavlov.kt.schema.generator.core.ir.TypeRef
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
@@ -474,6 +476,125 @@ class AptClassIntrospectorTest {
         }
     }
 
+    @Test
+    fun `should introspect enum as EnumNode with entries in declaration order`() {
+        val graph =
+            graph(
+                root = "com.example.Color",
+                javaEnum("com.example", "Color", "RED, GREEN, BLUE"),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<EnumNode> { enumNode ->
+            enumNode.entries shouldBe listOf("RED", "GREEN", "BLUE")
+        }
+    }
+
+    @Test
+    fun `should introspect enum field as ref to EnumNode`() {
+        val graph =
+            graph(
+                root = "com.example.Car",
+                javaEnum("com.example", "Color", "RED, GREEN, BLUE"),
+                javaClass("com.example", "Car", "public Color color;"),
+            )
+
+        graph.rootNode().properties.single().type.shouldBeInstanceOf<TypeRef.Ref> { ref ->
+            ref.id.value shouldBe "com.example.Color"
+            ref.nullable shouldBe false
+        }
+
+        graph.nodes.getValue(TypeId("com.example.Color")).shouldBeInstanceOf<EnumNode> { enumNode ->
+            enumNode.entries shouldBe listOf("RED", "GREEN", "BLUE")
+        }
+    }
+
+    @Test
+    fun `should treat Nullable-annotated enum field as nullable but keep it required`() {
+        val graph =
+            graph(
+                root = "com.example.Car",
+                // language=java
+                """
+                package com.example;
+
+                public @interface Nullable {}
+                """.trimIndent(),
+                javaEnum("com.example", "Color", "RED, GREEN, BLUE"),
+                javaClass(
+                    "com.example",
+                    "Car",
+                    """
+                    @Nullable
+                    public Color color;
+                    """.trimIndent(),
+                ),
+            )
+
+        val node = graph.rootNode()
+        assertSoftly(node) {
+            required.shouldContainExactlyInAnyOrder(setOf("color"))
+            properties.single().type.shouldBeInstanceOf<TypeRef.Ref> { ref ->
+                ref.id.value shouldBe "com.example.Color"
+                ref.nullable shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `should override enum name from JsonTypeName-style annotation on the enum class`() {
+        val graph =
+            graph(
+                root = "com.example.Color",
+                jacksonJsonTypeName(),
+                // language=java
+                """
+                package com.example;
+
+                import com.fasterxml.jackson.annotation.JsonTypeName;
+
+                @JsonTypeName("ColorPalette")
+                public enum Color {
+                    RED, GREEN, BLUE
+                }
+                """.trimIndent(),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<EnumNode> { enumNode ->
+            enumNode.name shouldBe "ColorPalette"
+        }
+    }
+
+    @Test
+    fun `should override enum entry names from JsonProperty-style annotation on enum constants`() {
+        val graph =
+            graph(
+                root = "com.example.Color",
+                jacksonJsonProperty(),
+                // language=java
+                """
+                package com.example;
+
+                import com.fasterxml.jackson.annotation.JsonProperty;
+
+                public enum Color {
+                    @JsonProperty("red")
+                    RED,
+                    @JsonProperty("green")
+                    GREEN,
+                    BLUE
+                }
+                """.trimIndent(),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<EnumNode> { enumNode ->
+            // BLUE has no override, so it falls back to its raw constant name
+            enumNode.entries shouldBe listOf("red", "green", "BLUE")
+        }
+    }
+
     //endregion
 
     //region helpers
@@ -512,6 +633,7 @@ class AptClassIntrospectorTest {
 
     private fun graph(
         root: String,
+        @Language("java")
         vararg sources: String,
     ): TypeGraph {
         val compiler =
@@ -575,11 +697,13 @@ class AptClassIntrospectorTest {
         }
     }
 
+    @Language("java")
     private fun javaClass(
         packageName: String,
         className: String,
-        members: String,
+        @Language("java") members: String,
     ): String =
+        // language=java
         """
         package $packageName;
 
@@ -588,21 +712,40 @@ class AptClassIntrospectorTest {
         }
         """.trimIndent()
 
+    @Language("java")
     private fun javaRecord(
         packageName: String,
         declaration: String,
     ): String =
+        // language=java
         """
         package $packageName;
 
         public record $declaration {}
         """.trimIndent()
 
+    @Language("java")
+    private fun javaEnum(
+        packageName: String,
+        enumName: String,
+        constants: String,
+    ): String =
+        // language=java
+        """
+        package $packageName;
+
+        public enum $enumName {
+        $constants
+        }
+        """.trimIndent()
+
     /**
      * Mirrors JSpecify's `@Nullable`, whose `@Target(TYPE_USE)` keeps it a pure type
      * annotation invisible to `Element.getAnnotationMirrors()`.
      */
+    @Language("java")
     private fun typeUseNullable(): String =
+        // language=java
         """
         package com.example;
 
@@ -611,6 +754,38 @@ class AptClassIntrospectorTest {
 
         @Target(ElementType.TYPE_USE)
         public @interface Nullable {}
+        """.trimIndent()
+
+    /**
+     * Stand-in for Jackson's `@JsonTypeName`, declared under its real FQN so
+     * [me.kpavlov.kt.schema.generator.core.ir.Introspections]'s name-override matching
+     * recognizes it without depending on the real Jackson library from this module.
+     */
+    @Language("java")
+    private fun jacksonJsonTypeName(): String =
+        // language=java
+        """
+        package com.fasterxml.jackson.annotation;
+
+        public @interface JsonTypeName {
+            String value();
+        }
+        """.trimIndent()
+
+    /**
+     * Stand-in for Jackson's `@JsonProperty`, declared under its real FQN so
+     * [me.kpavlov.kt.schema.generator.core.ir.Introspections]'s name-override matching
+     * recognizes it without depending on the real Jackson library from this module.
+     */
+    @Language("java")
+    private fun jacksonJsonProperty(): String =
+        // language=java
+        """
+        package com.fasterxml.jackson.annotation;
+
+        public @interface JsonProperty {
+            String value();
+        }
         """.trimIndent()
 
     private fun TypeGraph.rootNode(): ObjectNode =

--- a/kt-schema-generator-core/api/kt-schema-generator-core.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.api
@@ -67,6 +67,8 @@ public abstract class me/kpavlov/kt/schema/generator/core/ir/BaseIntrospectionCo
 	public final fun getNodes ()Ljava/util/Map;
 	protected final fun getTypeRefCache ()Ljava/util/Map;
 	protected final fun getVisitingTypes ()Ljava/util/Set;
+	protected final fun namedRef-b1Ot--I (Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)Lme/kpavlov/kt/schema/generator/core/ir/TypeRef$Ref;
+	public static synthetic fun namedRef-b1Ot--I$default (Lme/kpavlov/kt/schema/generator/core/ir/BaseIntrospectionContext;Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lme/kpavlov/kt/schema/generator/core/ir/TypeRef$Ref;
 	public abstract fun toRef (Ljava/lang/Object;)Lme/kpavlov/kt/schema/generator/core/ir/TypeRef;
 	protected final fun withCycleDetection-EEGM9QQ (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Z
 }

--- a/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
@@ -122,6 +122,7 @@ abstract class <#A: kotlin/Any> me.kpavlov.kt.schema.generator.core.ir/BaseIntro
         final fun <get-visitingTypes>(): kotlin.collections/MutableSet<#A> // me.kpavlov.kt.schema.generator.core.ir/BaseIntrospectionContext.visitingTypes.<get-visitingTypes>|<get-visitingTypes>(){}[0]
 
     abstract fun toRef(#A): me.kpavlov.kt.schema.generator.core.ir/TypeRef // me.kpavlov.kt.schema.generator.core.ir/BaseIntrospectionContext.toRef|toRef(1:0){}[0]
+    final fun namedRef(#A, me.kpavlov.kt.schema.generator.core.ir/TypeId, kotlin/Boolean = ..., kotlin/Function0<me.kpavlov.kt.schema.generator.core.ir/NamedTypeNode>): me.kpavlov.kt.schema.generator.core.ir/TypeRef.Ref // me.kpavlov.kt.schema.generator.core.ir/BaseIntrospectionContext.namedRef|namedRef(1:0;me.kpavlov.kt.schema.generator.core.ir.TypeId;kotlin.Boolean;kotlin.Function0<me.kpavlov.kt.schema.generator.core.ir.NamedTypeNode>){}[0]
     final fun withCycleDetection(#A, me.kpavlov.kt.schema.generator.core.ir/TypeId, kotlin/Function0<me.kpavlov.kt.schema.generator.core.ir/TypeNode>): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/BaseIntrospectionContext.withCycleDetection|withCycleDetection(1:0;me.kpavlov.kt.schema.generator.core.ir.TypeId;kotlin.Function0<me.kpavlov.kt.schema.generator.core.ir.TypeNode>){}[0]
 }
 

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/BaseIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/BaseIntrospectionContext.kt
@@ -82,4 +82,24 @@ public abstract class BaseIntrospectionContext<TType : Any> {
             visitingTypes -= type
         }
     }
+
+    /**
+     * Registers the [NamedTypeNode] built by [nodeBuilder] for [id] (idempotent via
+     * [withCycleDetection]) and returns a [TypeRef.Ref] to it.
+     *
+     * Named type nodes (enums, objects, polymorphic hierarchies) are always addressable by
+     * `$ref`, never inlined — encoding that contract in the return type keeps it enforced by
+     * the compiler instead of by convention repeated per front end. Currently used for enum
+     * registration across the reflection, KSP, APT and kotlinx.serialization front ends;
+     * object/polymorphic registration remains front-end-specific for now.
+     */
+    protected fun namedRef(
+        type: TType,
+        id: TypeId,
+        nullable: Boolean = false,
+        nodeBuilder: () -> NamedTypeNode,
+    ): TypeRef.Ref {
+        withCycleDetection(type, id, nodeBuilder)
+        return TypeRef.Ref(id, nullable)
+    }
 }

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -216,12 +216,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
      */
     private fun handleEnumType(type: KType): TypeRef {
         val id = createTypeId(type.klass)
-
-        withCycleDetection(type, id) {
-            createEnumNode(type.klass)
-        }
-
-        val ref = TypeRef.Ref(id, type.effectiveNullable())
+        val ref = namedRef(type, id, type.effectiveNullable()) { createEnumNode(type.klass) }
         if (!type.effectiveNullable()) typeRefCache[type] = ref
         return ref
     }

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -158,16 +158,15 @@ internal class SerializationIntrospectionContext(
     ): TypeRef {
         val id = descriptorId(descriptor)
 
-        withCycleDetection(descriptor, id) {
-            val entries = (0 until descriptor.elementsCount).map { descriptor.getElementName(it) }
-            EnumNode(
-                name = descriptor.unwrapSerialName().removeSuffix("?"),
-                entries = entries,
-                description = extractDescription(descriptor),
-            )
-        }
-
-        val ref = TypeRef.Ref(id, nullable)
+        val ref =
+            namedRef(descriptor, id, nullable) {
+                val entries = (0 until descriptor.elementsCount).map { descriptor.getElementName(it) }
+                EnumNode(
+                    name = descriptor.unwrapSerialName().removeSuffix("?"),
+                    entries = entries,
+                    description = extractDescription(descriptor),
+                )
+            }
         if (!nullable) typeRefCache[descriptor] = ref
         return ref
     }

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -12,6 +12,7 @@ import me.kpavlov.kt.schema.generator.core.defaultOpaqueTypeNames
 import me.kpavlov.kt.schema.generator.core.defaultPrimitiveTypeKinds
 import me.kpavlov.kt.schema.generator.core.ir.AnyNode
 import me.kpavlov.kt.schema.generator.core.ir.BaseIntrospectionContext
+import me.kpavlov.kt.schema.generator.core.ir.EnumNode
 import me.kpavlov.kt.schema.generator.core.ir.ListNode
 import me.kpavlov.kt.schema.generator.core.ir.MapNode
 import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
@@ -266,7 +267,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         val decl = type.enumClassDeclOrNull() ?: return null
         val id = decl.typeId()
 
-        withCycleDetection(type, id) {
+        return namedRef(type, id, nullable) {
             val entries =
                 decl.declarations
                     .filterIsInstance<KSClassDeclaration>()
@@ -275,14 +276,12 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                     .toList()
 
             val nameOverride = extractNameOverride(decl)
-            me.kpavlov.kt.schema.generator.core.ir.EnumNode(
+            EnumNode(
                 name = nameOverride ?: decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
                 entries = entries,
                 description = extractDescription(decl) { decl.descriptionFromKdoc() },
             )
         }
-
-        return TypeRef.Ref(id, nullable)
     }
 
     /**


### PR DESCRIPTION
## Description

Enums were previously unsupported: silently skipped as a root type and a hard build failure when referenced as a field. Adds a handleEnum path in AptIntrospectionContext producing EnumNode, admits ElementKind.ENUM as a candidate root type in JsonSchemaProcessor, and fixes a cross-root $defs caching gap where an enum shared by multiple @Schema roots would crash on the second root's cache hit.

Recognizes JsonTypeName (class) and JsonProperty (constants) overrides via the existing annotation-recognition convention, falling back to the FQN and raw constant names when absent. Adds matching SerialName enum coverage for KSP to close the same gap there.

Extracts a shared namedRef helper into BaseIntrospectionContext so all four introspection front ends (reflection, KSP, APT, kotlinx.serialization) register enum nodes through one path instead of duplicating the cycle-detection + TypeRef.Ref boilerplate; its return type (TypeRef.Ref) encodes that named nodes are always addressable by $ref, never inlined.

Also guards against an enum with zero constants, which previously produced a silently vacuous `"enum": []` schema.

**Related Issues:** #74

### New Features

  * Java annotation processing now supports generating JSON Schemas for enums, including custom type names, value names, descriptions, and references.
  * Expanded Java support documentation to include records, classes, interfaces, and enums.
  * Added enum schema generation coverage for Kotlin serialization, including customized serialized names.

### Bug Fixes

  * Improved enum references and shared definitions across generated schemas.

### Tests

  * Added integration coverage for Java and Kotlin enum schemas, nested enum properties, nullable values, and validation errors.

---

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [x] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements

