### PR TITLE
feat: Update examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,7 @@ kotlin {
 }
 ```
 
-For JVM-only projects and full configuration options, see *
-*[KSP Configuration Guide](docs/ksp.md)**.
+For JVM-only projects and full configuration options, see the [KSP Configuration Guide](docs/ksp.md).
 
 ## Runtime schema generation
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,11 @@
 
 **Generate JSON schemas and LLM function calling schemas from Java and Kotlin code — including classes you don't own.**
 
-> [!NOTE]
-> **kt-schema** is a fork of [kotlinx.schema](https://github.com/Kotlin/kotlinx-schema),
-> originally started by me, Konstantin Pavlov, at JetBrains, and is licensed under the Apache 2.0 License.
-
 Quick Links:
 
+- [Documentation Index](docs/README.md)
 - [KSP Configuration Guide](docs/ksp.md)
-- [Java Annotation Processor Guide](docs/apt.md)
+- [Java Annotation Processor Guide](docs/apt.md) — including Jackson-backed Java enum names
 - [Serialization-Based Schema Generation](docs/serializable.md)
 - [Project Architecture](docs/architecture.md)
 
@@ -63,7 +60,6 @@ Quick Links:
 
 **Developer Experience:**
 
-- Gradle plugin for one-line setup (experimental)
 - Type-safe Kotlin DSL for programmatic schema construction
 - Works everywhere: JVM, JS, iOS, macOS, Wasm
 
@@ -180,9 +176,6 @@ need to extract data class default values. Works equally well for `@Serializable
 
 ## Quick Start
 
-Recommended: use the Gradle plugin.
-It applies KSP for you, wires generated sources, and sets up task dependencies.
-
 Refer to the example projects [here](./examples).
 
 ### Annotate Your Models
@@ -233,7 +226,7 @@ kotlin {
 }
 ```
 
-For JVM-only projects, Maven, and full configuration options, see *
+For JVM-only projects and full configuration options, see *
 *[KSP Configuration Guide](docs/ksp.md)**.
 
 ## Runtime schema generation
@@ -1469,7 +1462,7 @@ For build instructions, development setup, and contribution guidelines, see [CON
 ## Requirements
 
 - Kotlin 2.2+
-- KSP 2 (applied automatically when using the Gradle plugin)
+- KSP 2 for compile-time KSP generation
 - _kotlinx-serialization-json_ for JsonObject support
 
 Tip: If you use `@Description` on primary constructor parameters, enable
@@ -1488,13 +1481,13 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ### Attribution
  
-**kt-schema** is a fork of [kotlinx.schema](https://github.com/Kotlin/kotlinx-schema), 
-originally developed by JetBrains s.r.o. and contributors, and is licensed under the Apache License, Version 2.0.
+**kt-schema** is an independently maintained fork of [kotlinx.schema](https://github.com/Kotlin/kotlinx-schema).
+Konstantin Pavlov originally started the work while at JetBrains.
  
 This project contains modified and unmodified portions of the original work. 
 Notable changes include renaming the Kotlin packages from `kotlinx.schema` to `me.kpavlov.kt.schema`, renaming Maven coordinates from `org.jetbrains.kotlinx` to `me.kpavlov`, and further independent development.
  
-See the [LICENSE](LICENSE) and [NOTICE]() files for licensing and attribution information.
+See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for licensing and attribution information.
 
 **kt-schema** is an independent project and is not affiliated with, endorsed by, or sponsored by JetBrains.
 "Kotlin" and "JetBrains" are trademarks of their respective owners.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,6 @@ models are built and deployed.
 
 ### Developer experience
 
-- Provides an experimental Gradle plugin for KSP setup and generated-source wiring.
 - Provides a type-safe Kotlin DSL for programmatic JSON Schema construction.
 - Supports JVM, JavaScript/Wasm, and Kotlin/Native targets where the selected generation mode is available.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,56 @@
+# Documentation
+
+kt-schema generates JSON Schema from Kotlin and Java models. Choose the generation path that matches how your
+models are built and deployed.
+
+## Features
+
+### Generation modes
+
+- **Compile-time Java APT** — generates schema resources for plain Java records, classes, interfaces, and enums
+  with no runtime generation overhead. It runs on the JVM and does not require Kotlin in your application code.
+- **Compile-time KSP** — generates schemas for annotated Kotlin classes with no runtime generation overhead and
+  supports Kotlin Multiplatform.
+- **Runtime reflection** — generates schemas for any JVM class, including types from third-party libraries.
+- **Runtime serial descriptors** — generates schemas for Kotlin `@Serializable` classes across supported Kotlin
+  platforms, including open polymorphism configured through `SerializersModule`.
+
+### LLM function calling
+
+- Generates function-calling schemas for OpenAI and Anthropic formats.
+- Extracts function names and descriptions.
+- Supports strict mode and parameter validation.
+
+### Annotation interoperability
+
+- Recognizes `@Description`, `@LLMDescription`, `@JsonPropertyDescription`, `@P`, and other configured
+  description annotations.
+- Extracts KDoc descriptions during KSP compile-time generation.
+- Reuses annotations from Jackson, LangChain4j, and Koog without changing the model.
+
+### Type support
+
+- Supports enums, collections, maps, nested objects, nullability, and generics, including star projections.
+- Emits `oneOf` schemas and discriminator fields for sealed classes and serialization-based open polymorphism.
+- Represents nullable parameters as union types such as `["string", "null"]`.
+- Supports JSON Schema constraints, including minimum/maximum values, patterns, and formats, through the DSL.
+- Tracks compile-time defaults and extracts runtime defaults.
+- Deduplicates named types through `$ref` and `$defs`.
+- Maps `kotlin.Any` to `{}`, which accepts any JSON value.
+
+### Developer experience
+
+- Provides an experimental Gradle plugin for KSP setup and generated-source wiring.
+- Provides a type-safe Kotlin DSL for programmatic JSON Schema construction.
+- Supports JVM, JavaScript/Wasm, and Kotlin/Native targets where the selected generation mode is available.
+
+## Guides
+
+- [KSP Configuration Guide](ksp.md) — compile-time schemas for annotated Kotlin models.
+- [Java Annotation Processor Guide](apt.md) — compile-time schema resources for Java records, classes,
+  interfaces, and enums; includes Jackson enum-name support.
+- [Serialization-Based Schema Generation](serializable.md) — runtime schemas from Kotlin serialization descriptors.
+- [Project Architecture](architecture.md) — shared metadata, IR, and JSON Schema emission.
+
+For runtime reflection, function-calling schemas, annotation support, and the JSON Schema DSL, see the
+[project README](../README.md).

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -12,6 +12,7 @@
   * [Extended example](#extended-example)
   * [Reading the resource at runtime](#reading-the-resource-at-runtime)
 * [Supported types](#supported-types)
+  * [Jackson enum names](#jackson-enum-names)
   * [Marking a property nullable/optional](#marking-a-property-nullableoptional)
 * [See Also](#see-also)
 
@@ -303,6 +304,27 @@ try (InputStream in = Person.class.getClassLoader()
 
 Not yet supported: sealed class hierarchies (polymorphic `oneOf` with discriminators). Processing an
 unsupported type fails the build with a descriptive error rather than emitting an incomplete schema.
+
+### Jackson enum names
+
+When the application already uses Jackson, `kt-schema-apt` uses `@JsonProperty` on enum constants as their
+JSON Schema values and `@JsonTypeName` on the enum as its schema `$id`. The generated resource path still
+uses the declared Java type name.
+
+```java
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("PriorityLevel")
+public enum Priority {
+    @JsonProperty("low") LOW,
+    @JsonProperty("medium") MEDIUM,
+    @JsonProperty("high") HIGH
+}
+```
+
+This produces a schema whose `$id` is `PriorityLevel` and whose `enum` is `["low", "medium", "high"]`,
+at `META-INF/kt-schema/schemas/com/example/Priority.json` for a `com.example.Priority` enum.
 
 ### Marking a property nullable/optional
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,18 +22,17 @@ The library implements the following pipeline:
 ```mermaid
 graph LR
     subgraph Sources["📦 SOURCES"]
+        Java["Java Classes<br/>Third-party libs"]
+        Functions["Kotlin Functions"]
         Kotlin["Kotlin Classes<br/>@Schema annotated"]
         KSerializer["SerialDescriptor"]
-        Java["Java Classes<br/>Third-party libs"]
-        JavaApt["Java Records/Classes/Interfaces<br/>@Schema or rootPackage"]
-        Functions["Kotlin Functions"]
     end
 
     subgraph Introspectors["🔍 Stage 1: INTROSPECTORS"]
         KSP["KspSchemaIntrospector<br/><i>compile-time</i>"]
+        Serialization["SerializationClassSchemaIntrospector<br/><i>runtime</i>"]
         Apt["AptClassIntrospector<br/><i>compile-time</i>"]
         Reflect["ReflectionSchemaIntrospector<br/><i>runtime</i>"]
-        Serialization["SerializationClassSchemaIntrospector<br/><i>runtime</i>"]
     end
 
     subgraph IR["🧬 INTERNAL REPRESENTATION"]
@@ -58,7 +57,7 @@ graph LR
     Kotlin --> KSP
     KSerializer --> Serialization
     Java --> Reflect
-    JavaApt --> Apt
+    Java --> Apt
     Functions --> KSP
     Functions --> Reflect
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,6 @@ C4Context
         System(kxsJsn, "kt-schema-json")
         System(kxsKsp, "kt-schema-ksp")
         System(kxsApt, "kt-schema-apt")
-        System(kxsGradle, "kt-schema-gradle-plugin")
     }
 
     Rel(kxsGenJson, kxsGenCore, "uses")
@@ -119,7 +118,6 @@ C4Context
     Rel(kxsGenCore, kxsAnnotations, "knows")
     Rel(kxsKsp, kxsGenJson, "uses")
     Rel(kxsApt, kxsGenJson, "uses")
-    Rel(kxsGradle, kxsKsp, "uses")
 
     Boundary(userCode, "User's Application Code") {
         System_Ext(userModels, "User Domain Models")
@@ -145,7 +143,7 @@ Top-level modules you might interact with:
     - `KClass<T>.jsonSchemaString: String`
 - **kt-schema-apt** — [JSR 269 annotation processor](apt.md) for plain Java projects; generates a JSON Schema
   resource per processed type instead of Kotlin extensions
-- **ksp-integration-tests** — KSP end‑to‑end tests for generation without the Gradle plugin
+- **ksp-integration-tests** — KSP end‑to‑end tests for schema generation
 - **apt-integration-tests** — Java-only end‑to‑end tests for `kt-schema-apt`
 
 ### Workflow
@@ -180,4 +178,3 @@ sequenceDiagram
    with respect to respecting _Config_ object and returns it to SchemaGenerator
 
 [kser-descriptor]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.descriptors/-serial-descriptor/
-

--- a/docs/ksp.md
+++ b/docs/ksp.md
@@ -7,12 +7,10 @@
   * [Google KSP gradle plugin](#google-ksp-gradle-plugin)
     * [Multiplatform projects](#multiplatform-projects)
     * [JVM-only projects](#jvm-only-projects)
-  * [Maven Plugin](#maven-plugin)
 * [Configuration options](#configuration-options)
   * [Options reference](#options-reference)
   * [Filtering by class/function name](#filtering-by-classfunction-name)
     * [Google KSP plugin](#google-ksp-plugin)
-    * [Maven plugin](#maven-plugin)
   * [Option priority](#option-priority)
 * [Generated Code](#generated-code)
 * [See Also](#see-also)
@@ -23,7 +21,7 @@ Generate JSON schemas at compile time with zero runtime overhead using the `kt-s
 
 ## Setup
 
-Configure the KSP processor directly in your Gradle build script, Maven pom.xml, or use the dedicated Gradle plugin.
+Configure the KSP processor with the Google KSP Gradle plugin.
 
 ### Google KSP gradle plugin
 
@@ -74,51 +72,6 @@ dependencies {
 sourceSets.main.kotlin.srcDir("build/generated/ksp/main/kotlin")
 ```
 
-### Maven Plugin
-
-You may also run schema generation with KSP in your Maven projects.
-
-Add the [`ksp-maven-plugin`](https://github.com/kpavlov/ksp-maven-plugin) with the processor dependency
-and include the annotations library in your project.
-
-```xml
-
-<plugin>
-    <groupId>me.kpavlov.ksp.maven</groupId>
-    <artifactId>ksp-maven-plugin</artifactId>
-    <version>0.3.0</version>
-    <extensions>true</extensions>
-    <dependencies>
-        <dependency>
-            <groupId>me.kpavlov</groupId>
-            <artifactId>kt-schema-ksp</artifactId>
-            <version>${kt-schema.version}</version>
-        </dependency>
-    </dependencies>
-    <configuration>
-        <options>
-            <me.kpavlov.kt.schema.rootPackage>com.example</me.kpavlov.kt.schema.rootPackage>
-        </options>
-    </configuration>
-</plugin>
-
-<!-- In <dependencies> -->
-<dependencies>
-    <dependency>
-        <groupId>me.kpavlov</groupId>
-        <artifactId>kt-schema-annotations</artifactId>
-        <version>${kt-schema.version}</version>
-    </dependency>
-</dependencies>
-
-<properties>
-<!-- check latest version: https://central.sonatype.com/artifact/me.kpavlov/kt-schema-ksp -->
-<kt-schema.version>0.0.5</kt-schema.version>
-</properties>
-```
-
-Check out an [example project](https://github.com/kpavlov/kt-schema/tree/main/examples/maven-ksp).
-
 ## Configuration options
 
 Options can be set globally in your build configuration or overridden per-class via `@Schema`.
@@ -163,17 +116,6 @@ ksp {
 }
 ```
 
-#### Maven plugin
-
-```xml
-<configuration>
-    <options>
-        <me.kpavlov.kt.schema.include>com.example.api.**, com.example.dto.**</me.kpavlov.kt.schema.include>
-        <me.kpavlov.kt.schema.exclude>**.internal.**, **.*Internal</me.kpavlov.kt.schema.exclude>
-    </options>
-</configuration>
-```
-
 > [!TIP]
 > For large projects, combine `rootPackage` with `include` for maximum build performance:
 > `rootPackage` narrows the KSP symbol scan, then `include` filters the remaining candidates.
@@ -181,7 +123,7 @@ ksp {
 ### Option priority
 
 1. **Annotation Parameter** (highest) — `@Schema(withSchemaObject = true)`
-2. **KSP Argument** — Global processor options (e.g., `arg()` in Gradle or `<options>` in Maven)
+2. **KSP Argument** — Global processor options passed through the Gradle `ksp { arg(...) }` block
 3. **Default Value** (lowest)
 
 > [!TIP]

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,4 @@ This directory contains example projects demonstrating various use cases of **kt
 - **[gradle-google-ksp](gradle-google-ksp):**  Generate JSON schema from Kotlin classes 
     using [Kotlin Symbol Processing (KSP)](https://kotlinlang.org/docs/ksp-overview.html) 
     via [Google KSP Gradle plugin](https://github.com/google/ksp).
-- **[maven-ksp](maven-ksp):**  Generate JSON schema from Kotlin classes 
-    using [Kotlin Symbol Processing (KSP)](https://kotlinlang.org/docs/ksp-overview.html) 
-    via [KSP Maven plugin](https://github.com/kpavlov/ksp-maven-plugin).
 - **[maven-java](maven-java):**  Generate JSON schema from plain Java records, classes and interfaces using the `kt-schema-apt` JSR 269 annotation processor. See [Java Annotation Processor](../docs/apt.md) for the processor documentation.

--- a/examples/gradle-google-ksp/gradle.properties
+++ b/examples/gradle-google-ksp/gradle.properties
@@ -12,4 +12,4 @@ name = gradle-google-ksp-example
 group=me.kpavlov.kt.schema.examples
 version=1.0-SNAPSHOT
 
-ktSchemaVersion=0.8.1
+ktSchemaVersion=0.8.2

--- a/examples/maven-java/README.md
+++ b/examples/maven-java/README.md
@@ -11,13 +11,14 @@ expected JSON using JUnit 6 and JsonUnit.
 
 - Schemas generated during `compile` through Maven `annotationProcessorPaths`
 - Type selection via `rootPackage` + `include` globs — no `@Schema` annotations required
-- Records, plain classes, and interfaces, including nested types
+- Records, plain classes, interfaces, and enums, including nested types
 - JavaBeans accessors: `isActive()` becomes `active`, `getName()` becomes `name`
 - Jackson annotations recognized out of the box:
   - `@JsonProperty` renames a property (`getEmployeeId()` → `employee_id`)
   - `@JsonPropertyDescription` / `@JsonClassDescription` become schema descriptions
   - `@JsonIgnore` keeps a field out of the schema
 - Collections: `List`/`Set` become `array` with `items`, `Map` becomes `object` with `additionalProperties`
+- Enums become `type: string` with an `enum` array listing the constants in declaration order
 - Nested types land in `$defs` and are referenced with `$ref`, deduplicated
 - Self- and mutual recursion produce cyclic `$ref`s back into `$defs`
 - JSpecify `@Nullable` marks a property nullable without making it optional
@@ -39,9 +40,11 @@ public interface Employee {
 ```
 
 - `Employee` — interface; `manager`/`reports` make the schema recursive. `manager` and `department`
-  are annotated with JSpecify `@Nullable`.
+  are annotated with JSpecify `@Nullable`. Its `employmentType` accessor references the `EmploymentType` enum.
 - `ContactInfo`, `Address` — records; `ContactInfo` holds a `List<Address>` of nested records.
 - `Compensation` — plain class with a `@JsonIgnore` field.
+- `EmploymentType` — enum (`FULL_TIME`, `PART_TIME`, `CONTRACTOR`) whose JSON values are lowercased via
+  `@JsonProperty`; emitted as a string schema with an `enum` array.
 - `Department` — record referencing `Employee`, making the two schemas mutually recursive.
 
 ## Nullable properties

--- a/examples/maven-java/pom.xml
+++ b/examples/maven-java/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <kt-schema.version>0.8.1</kt-schema.version>
+        <kt-schema.version>0.8.2</kt-schema.version>
         <jackson.version>3.2.1</jackson.version>
         <junit.version>6.1.2</junit.version>
         <assertj.version>3.27.7</assertj.version>

--- a/examples/maven-java/src/main/java/com/example/orgchart/Employee.java
+++ b/examples/maven-java/src/main/java/com/example/orgchart/Employee.java
@@ -33,6 +33,9 @@ public interface Employee {
     @JsonPropertyDescription("Compensation package of the employee")
     Compensation getCompensation();
 
+    @JsonPropertyDescription("Employment type of the employee")
+    EmploymentType getEmploymentType();
+
     @JsonPropertyDescription("Department the employee belongs to")
     @Nullable
     Department getDepartment();

--- a/examples/maven-java/src/main/java/com/example/orgchart/EmploymentType.java
+++ b/examples/maven-java/src/main/java/com/example/orgchart/EmploymentType.java
@@ -1,0 +1,21 @@
+package com.example.orgchart;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * Employment type of an employee. Enums are emitted as a JSON Schema string with an
+ * {@code enum} array listing the constants in declaration order; {@code @JsonProperty}
+ * renames the JSON values (here, to lowercase).
+ */
+@JsonClassDescription("Employment type of an employee.")
+@JsonTypeName("Employment")
+public enum EmploymentType {
+    @JsonProperty("full_time")
+    FULL_TIME,
+    @JsonProperty("part_time")
+    PART_TIME,
+    @JsonProperty("contractor")
+    CONTRACTOR
+}

--- a/examples/maven-java/src/test/java/com/example/orgchart/OrgChartSchemaTest.java
+++ b/examples/maven-java/src/test/java/com/example/orgchart/OrgChartSchemaTest.java
@@ -67,6 +67,10 @@ class OrgChartSchemaTest {
                       "$ref": "#/$defs/com.example.orgchart.Compensation",
                       "description": "Compensation package of the employee"
                     },
+                    "employmentType": {
+                      "$ref": "#/$defs/Employment",
+                      "description": "Employment type of the employee"
+                    },
                     "department": {
                       "description": "Department the employee belongs to",
                       "oneOf": [{"type":"null"}, {"$ref":"#/$defs/com.example.orgchart.Department"}]
@@ -103,6 +107,7 @@ class OrgChartSchemaTest {
                     "active",
                     "contactInfo",
                     "compensation",
+                    "employmentType",
                     "department",
                     "manager",
                     "reports",
@@ -177,6 +182,11 @@ class OrgChartSchemaTest {
                   },
                   "required": ["baseSalary", "annualBonus", "currency"],
                   "additionalProperties": false
+                },
+                "Employment": {
+                  "type": "string",
+                  "description": "Employment type of an employee.",
+                  "enum": ["full_time", "part_time", "contractor"]
                 },
                 "com.example.orgchart.Department": {
                   "type": "object",

--- a/examples/maven-ksp/pom.xml
+++ b/examples/maven-ksp/pom.xml
@@ -16,7 +16,7 @@
         <kotlin.version>2.3.21</kotlin.version>
         <maven.compiler.release>25</maven.compiler.release>
         <ksp.plugin.version>0.4.6</ksp.plugin.version>
-        <kt-schema.version>0.8.1</kt-schema.version>
+        <kt-schema.version>0.8.2</kt-schema.version>
         <kotest.version>6.1.11</kotest.version>
         <kotlinx-serialization.version>1.10.0</kotlinx-serialization.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Description

### Documentation

- Added quick links and expanded guides covering generation modes, configuration, architecture, type support, and function-calling integrations.
- Documented Java record and enum support, including Jackson enum naming and schema metadata.
- Clarified KSP setup, filtering, and configuration requirements.
- Updated project attribution, licensing information, and architecture references.

### Examples

- Added employment type data to the Java example, including generated enum schema values.
- Updated examples to version 0.8.2 and streamlined the listed projects.
