### PR TITLE
feat: support default values for enums and properties via Jackson annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,20 @@ This library solves three key challenges:
 |:----------------------------------|:-------------------------------:|:--------------------------:|:----------------------------------------------:|:---------------------------------------------------:|
 | **Platforms**                     |       JVM + Multiplatform       |          JVM only          |              JVM + Multiplatform               |                      JVM only                       |
 | **When generated**                |          Compile-time           |        Compile-time        |                    Runtime                     |                       Runtime                       |
-| **Requires annotation processor** |            Yes (KSP)            |          Yes (APT)         |                       No                       |                         No                          |
+| **Requires annotation processor** |            Yes (KSP)            |         Yes (APT)          |                       No                       |                         No                          |
 | **Class must be `@Serializable`** |               No                |             No             |                      Yes                       |                         No                          |
-| **Annotate class with `@Schema`** |            Required             |    Not required¹           |                  Not required                  |                    Not required                     |
-| **KDoc extracted to description** |                ✅                |             ❌              |                       ❌                        |                          ❌                          |
-| **Extract default values**        |                ❌                |             ❌              |                       ❌                        |                          ✅                          |
-| **Third-party classes**           |                ❌                |             ❌              |            ✅ (only `@Serializable`)            |                   ✅ any JVM class                   |
+| **Annotate class with `@Schema`** |            Required             |       Not required¹        |                  Not required                  |                    Not required                     |
+| **KDoc extracted to description** |               ✅                |             ❌             |                       ❌                       |                         ❌                          |
+| **Extract default values**        |            Partial²             |          Partial²          |                       ❌                       |                         ✅                          |
+| **Third-party classes**           |               ❌                |             ❌             |           ✅ (only `@Serializable`)            |                  ✅ any JVM class                   |
 
 ¹ with the `rootPackage` option — see [Java Annotation Processor Guide](docs/apt.md#triggering-schema-generation).
+
+² via Jackson's `@JsonEnumDefaultValue`, placed on an enum constant — shown as `default` on that enum's own schema
+in the generated output. `@JsonProperty(defaultValue = "...")` is also recognized and populates the property
+internally, but neither processor's standard generated resource surfaces it, since both mark every property
+required regardless of default presence (KSP/APT can't evaluate a real Kotlin/Java default-value expression at
+compile time, unlike reflection) — see [Multi-Framework Annotation Support](#multi-framework-annotation-support).
 
 - **[Pick KSP](docs/ksp.md)** when you own the classes, want zero runtime overhead, and target Multiplatform or need KDoc
 in your schema.
@@ -1199,6 +1205,21 @@ Beyond descriptions, kt-schema also recognizes **name overrides** and **ignore m
 |----------------------------|---------------------------------------------|
 | `JsonIgnore` (any package) | excludes the property/field from the schema |
 
+**Default values** — matched by **fully qualified name** (case-sensitive); mainly useful for the KSP and Java APT
+processors, which can't evaluate a real Kotlin/Java default-value expression at compile time:
+
+| Annotation                                                       | Maps to                                                                                                     |
+|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `com.fasterxml.jackson.annotation.JsonEnumDefaultValue`          | the enum constant it's placed on becomes that enum type's `default` (on the enum's own schema, in `$defs`)  |
+| `com.fasterxml.jackson.annotation.JsonProperty(defaultValue=..)` | the property's default value, internally                                                                    |
+
+> [!NOTE]
+> The `@JsonEnumDefaultValue`-derived `default` always appears in the generated output, since it's a property of
+> the enum's own schema. `@JsonProperty(defaultValue = "...")` is recognized and populates the property internally,
+> but doesn't appear in — or exclude the property from `required` in — the KSP/APT processors' standard generated
+> resource, since both mark every property required regardless of default presence. It does apply when building a
+> schema through `TypeGraphToJsonSchemaTransformer` with a non-strict `JsonSchemaConfig` yourself.
+
 ### How It Works
 
 Each annotation category (description, name-override, ignore) is configured with its own list of recognized names.
@@ -1230,6 +1251,9 @@ By default, the library recognizes:
 **Ignore annotations**: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType, JsonIgnore
 **Name-override annotations**: kotlinx.serialization.SerialName, com.fasterxml.jackson.annotation.JsonProperty, com.fasterxml.jackson.annotation.JsonTypeName
 **Name-override attributes**: value
+**Enum-default annotations**: com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+**Default-value annotations**: com.fasterxml.jackson.annotation.JsonProperty
+**Default-value attributes**: defaultValue
 
 > [!NOTE]
 > Annotation names containing a dot (e.g., `kotlinx.serialization.SerialName`) are matched
@@ -1248,6 +1272,11 @@ introspector.annotations.description.attributes=value,description,text
 # Name-override annotations (use FQN for precise matching)
 introspector.annotations.name.names=kotlinx.serialization.SerialName
 introspector.annotations.name.attributes=value
+
+# Default-value annotations (use FQN for precise matching)
+introspector.annotations.enumDefault.names=com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+introspector.annotations.defaultValue.names=com.fasterxml.jackson.annotation.JsonProperty
+introspector.annotations.defaultValue.attributes=defaultValue
 ```
 
 **Note**: The library falls back to built-in defaults if the configuration file is missing or cannot be loaded.

--- a/docs/apt.md
+++ b/docs/apt.md
@@ -13,6 +13,7 @@
   * [Reading the resource at runtime](#reading-the-resource-at-runtime)
 * [Supported types](#supported-types)
   * [Jackson enum names](#jackson-enum-names)
+  * [Default values](#default-values)
   * [Marking a property nullable/optional](#marking-a-property-nullableoptional)
 * [See Also](#see-also)
 
@@ -325,6 +326,33 @@ public enum Priority {
 
 This produces a schema whose `$id` is `PriorityLevel` and whose `enum` is `["low", "medium", "high"]`,
 at `META-INF/kt-schema/schemas/com/example/Priority.json` for a `com.example.Priority` enum.
+
+### Default values
+
+Java has no default-parameter expressions to evaluate, but two Jackson annotations are recognized as an explicit,
+compile-time-visible substitute:
+
+```java
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Priority {
+    LOW,
+    @JsonEnumDefaultValue MEDIUM,
+    HIGH
+}
+
+public record Job(Priority priority, @JsonProperty(defaultValue = "30") int timeoutSeconds) {}
+```
+
+`@JsonEnumDefaultValue`, placed on one enum constant, marks it as that enum's `default` — always shown on the
+enum's own schema in `$defs`, since it describes the *type*, not any one property using it. `@JsonProperty(defaultValue = "...")`
+populates the property's default internally, but — like every property here — `kt-schema-apt`'s generated resource
+always marks it required and never shows the `default` keyword for it, since Java has no reliable way to know
+whether a value truly behaves as optional. Both are configurable via `kt-schema.properties`
+(`introspector.annotations.enumDefault.names`, `introspector.annotations.defaultValue.names`,
+`introspector.annotations.defaultValue.attributes`) — see
+[Multi-Framework Annotation Support](../README.md#multi-framework-annotation-support).
 
 ### Marking a property nullable/optional
 

--- a/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDefaultValueModel.kt
+++ b/ksp-integration-tests/src/main/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDefaultValueModel.kt
@@ -1,0 +1,24 @@
+package me.kpavlov.kt.schema.integration.type
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.kpavlov.kt.schema.Schema
+
+// Enum class with a Jackson @JsonEnumDefaultValue-annotated constant.
+@Schema
+enum class Severity {
+    LOW,
+
+    @JsonEnumDefaultValue
+    MEDIUM,
+    HIGH,
+}
+
+// Model exercising default-value extraction from Jackson annotations: an enum type default
+// (@JsonEnumDefaultValue) and a property default (@JsonProperty(defaultValue = "...")).
+@Schema
+data class JacksonDefaultValueModel(
+    val severity: Severity,
+    @JsonProperty(defaultValue = "30")
+    val timeoutSeconds: Int,
+)

--- a/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDefaultValueModelSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/me/kpavlov/kt/schema/integration/type/JacksonDefaultValueModelSchemaTest.kt
@@ -1,0 +1,43 @@
+package me.kpavlov.kt.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/**
+ * Tests for JacksonDefaultValueModel schema generation - default-value extraction from
+ * Jackson's @JsonEnumDefaultValue (enum type default) and @JsonProperty(defaultValue = "...")
+ * (property default).
+ */
+class JacksonDefaultValueModelSchemaTest {
+    @Test
+    fun `generates enum default from JsonEnumDefaultValue and property default from JsonProperty defaultValue`() {
+        val schema = JacksonDefaultValueModel::class.jsonSchemaString
+
+        // KSP always marks every property required and never shows property-level defaults
+        // (JsonSchemaConfig doc: "Does not work reliably with KSP because KSP cannot detect
+        // default values in the same compilation unit"). The enum's own type-level default is
+        // unaffected by that, since it's emitted unconditionally on the enum's own $defs schema.
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.integration.type.JacksonDefaultValueModel",
+              "type": "object",
+              "properties": {
+                "severity": { "$ref": "#/$defs/me.kpavlov.kt.schema.integration.type.Severity" },
+                "timeoutSeconds": { "type": "integer" }
+              },
+              "required": ["severity", "timeoutSeconds"],
+              "additionalProperties": false,
+              "$defs": {
+                "me.kpavlov.kt.schema.integration.type.Severity": {
+                  "type": "string",
+                  "enum": ["LOW", "MEDIUM", "HIGH"],
+                  "default": "MEDIUM"
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -268,12 +268,15 @@ internal class AptIntrospectionContext(
                     if (isIgnored(targets)) return@forEach
                     val propertyName = nameOverrideFor(targets) ?: name
                     val componentType = component.asType()
-                    // Optional by convention (type-name pattern or @Nullable-style annotation) —
-                    // excluded from `required`, the same way a Kotlin default value is handled.
-                    val optional = isOptionalByTypeName(componentType) || isOptionalAnnotated(targets)
+                    val defaultValue = defaultValueFor(targets)
+                    // Optional by convention (type-name pattern, @Nullable-style annotation, or a
+                    // known default value) — excluded from `required`, the same way a Kotlin
+                    // default value is handled.
+                    val optional =
+                        isOptionalByTypeName(componentType) || isOptionalAnnotated(targets) || defaultValue != null
                     if (!optional) required += propertyName
                     val description = recordComponentDescription(component, field)
-                    props += toProperty(propertyName, componentType, description, targets, optional)
+                    props += toProperty(propertyName, componentType, description, targets, optional, defaultValue)
                 }
 
                 objectNode(element, props, required)
@@ -291,11 +294,17 @@ internal class AptIntrospectionContext(
 
         return namedRef(type, id) {
             buildOrGet(type, id) {
-                val entries =
+                val constants =
                     element.enclosedElements
                         .filterIsInstance<VariableElement>()
                         .filter { it.kind == ElementKind.ENUM_CONSTANT }
-                        .map { constant -> nameOverrideFor(listOf(constant)) ?: constant.simpleName.toString() }
+                var defaultValue: String? = null
+                val entries =
+                    constants.map { constant ->
+                        val entryName = nameOverrideFor(listOf(constant)) ?: constant.simpleName.toString()
+                        if (defaultValue == null && isEnumDefaultAnnotated(constant)) defaultValue = entryName
+                        entryName
+                    }
                 check(entries.isNotEmpty()) {
                     "Enum ${element.qualifiedName} has no constants; cannot generate a JSON Schema enum"
                 }
@@ -303,6 +312,7 @@ internal class AptIntrospectionContext(
                 EnumNode(
                     name = nameOverrideFor(listOf(element)) ?: element.qualifiedName.toString(),
                     entries = entries,
+                    defaultValue = defaultValue,
                     description = extractDescription(element),
                 )
             }
@@ -329,10 +339,21 @@ internal class AptIntrospectionContext(
                         if (isIgnored(listOf(field))) return@forEach
                         val propertyName = nameOverrideFor(listOf(field)) ?: name
                         val fieldType = field.asType()
-                        val optional = isOptionalByTypeName(fieldType) || isOptionalAnnotated(listOf(field))
+                        val defaultValue = defaultValueFor(listOf(field))
+                        val optional =
+                            isOptionalByTypeName(fieldType) ||
+                                isOptionalAnnotated(listOf(field)) ||
+                                defaultValue != null
                         if (!optional) required += propertyName
                         props +=
-                            toProperty(propertyName, fieldType, extractDescription(field), listOf(field), optional)
+                            toProperty(
+                                propertyName,
+                                fieldType,
+                                extractDescription(field),
+                                listOf(field),
+                                optional,
+                                defaultValue,
+                            )
                     }
 
                 objectNode(element, props, required)
@@ -363,9 +384,21 @@ internal class AptIntrospectionContext(
                         if (isIgnored(listOf(method))) return@forEach
                         val name = nameOverrideFor(listOf(method)) ?: propertyName(method.simpleName.toString())
                         val returnType = method.returnType
-                        val optional = isOptionalByTypeName(returnType) || isOptionalAnnotated(listOf(method))
+                        val defaultValue = defaultValueFor(listOf(method))
+                        val optional =
+                            isOptionalByTypeName(returnType) ||
+                                isOptionalAnnotated(listOf(method)) ||
+                                defaultValue != null
                         if (!optional) required += name
-                        props += toProperty(name, returnType, extractDescription(method), listOf(method), optional)
+                        props +=
+                            toProperty(
+                                name,
+                                returnType,
+                                extractDescription(method),
+                                listOf(method),
+                                optional,
+                                defaultValue,
+                            )
                     }
 
                 objectNode(element, props, required)
@@ -474,6 +507,7 @@ internal class AptIntrospectionContext(
         description: String?,
         annotationTargets: List<Element> = emptyList(),
         optional: Boolean = false,
+        defaultValue: String? = null,
     ): Property =
         Property(
             name = name,
@@ -484,6 +518,7 @@ internal class AptIntrospectionContext(
                 },
             description = description,
             hasDefaultValue = optional,
+            defaultValue = defaultValue,
         )
 
     private fun objectNode(
@@ -548,6 +583,27 @@ internal class AptIntrospectionContext(
     private fun nameOverrideFor(targets: List<Element>): String? =
         targets.firstNotNullOfOrNull(::extractNameOverride)
 
+    /**
+     * Returns the first default-value override (e.g. from `@JsonProperty(defaultValue = "...")`)
+     * found across the given annotation targets, in order, or null if none provides one.
+     */
+    private fun defaultValueFor(targets: List<Element>): String? =
+        targets.firstNotNullOfOrNull(::extractDefaultValueOverride)
+
+    private fun extractDefaultValueOverride(element: Element): String? =
+        element.annotationMirrors.firstNotNullOfOrNull { mirror ->
+            val annotationElement = mirror.annotationType.asElement() as TypeElement
+            val args =
+                mirror.elementValues.entries.map { (attribute, value) ->
+                    attribute.simpleName.toString() to value.value
+                }
+            Introspections.getDefaultValueFromAnnotation(
+                simpleName = annotationElement.simpleName.toString(),
+                qualifiedName = annotationElement.qualifiedName.toString(),
+                annotationArguments = args,
+            )
+        }
+
     private fun extractNameOverride(element: Element): String? =
         element.annotationMirrors.firstNotNullOfOrNull { mirror ->
             val annotationElement = mirror.annotationType.asElement() as TypeElement
@@ -610,6 +666,19 @@ internal class AptIntrospectionContext(
         element.annotationMirrors.any { mirror ->
             val annotationElement = mirror.annotationType.asElement() as TypeElement
             Introspections.isOptionalAnnotation(
+                simpleName = annotationElement.simpleName.toString(),
+                qualifiedName = annotationElement.qualifiedName.toString(),
+            )
+        }
+
+    /**
+     * Returns `true` if the given element carries a recognized enum-default-value marker
+     * (e.g. `@JsonEnumDefaultValue`).
+     */
+    private fun isEnumDefaultAnnotated(element: Element): Boolean =
+        element.annotationMirrors.any { mirror ->
+            val annotationElement = mirror.annotationType.asElement() as TypeElement
+            Introspections.isEnumDefaultAnnotation(
                 simpleName = annotationElement.simpleName.toString(),
                 qualifiedName = annotationElement.qualifiedName.toString(),
             )

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -595,6 +595,59 @@ class AptClassIntrospectorTest {
         }
     }
 
+    @Test
+    fun `should mark JsonEnumDefaultValue-annotated constant as EnumNode default`() {
+        val graph =
+            graph(
+                root = "com.example.Color",
+                jacksonJsonEnumDefaultValue(),
+                // language=java
+                """
+                package com.example;
+
+                import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+                public enum Color {
+                    RED,
+                    @JsonEnumDefaultValue
+                    GREEN,
+                    BLUE
+                }
+                """.trimIndent(),
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        graph.nodes.getValue(rootRef.id).shouldBeInstanceOf<EnumNode> { enumNode ->
+            enumNode.defaultValue shouldBe "GREEN"
+        }
+    }
+
+    @Test
+    fun `should populate Property defaultValue from JsonProperty defaultValue-style annotation`() {
+        val graph =
+            graph(
+                root = "com.example.Car",
+                jacksonJsonProperty(),
+                javaClass(
+                    "com.example",
+                    "Car",
+                    """
+                    @com.fasterxml.jackson.annotation.JsonProperty(defaultValue = "30")
+                    public int timeout;
+                    """.trimIndent(),
+                ),
+            )
+
+        val node = graph.rootNode()
+        assertSoftly(node) {
+            required.shouldContainExactlyInAnyOrder(emptySet())
+            properties.single().apply {
+                hasDefaultValue shouldBe true
+                defaultValue shouldBe "30"
+            }
+        }
+    }
+
     //endregion
 
     //region helpers
@@ -784,7 +837,23 @@ class AptClassIntrospectorTest {
         package com.fasterxml.jackson.annotation;
 
         public @interface JsonProperty {
-            String value();
+            String value() default "";
+            String defaultValue() default "";
+        }
+        """.trimIndent()
+
+    /**
+     * Stand-in for Jackson's `@JsonEnumDefaultValue`, declared under its real FQN so
+     * [me.kpavlov.kt.schema.generator.core.ir.Introspections]'s enum-default matching recognizes
+     * it without depending on the real Jackson library from this module.
+     */
+    @Language("java")
+    private fun jacksonJsonEnumDefaultValue(): String =
+        // language=java
+        """
+        package com.fasterxml.jackson.annotation;
+
+        public @interface JsonEnumDefaultValue {
         }
         """.trimIndent()
 

--- a/kt-schema-generator-core/api/kt-schema-generator-core.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.api
@@ -92,14 +92,16 @@ public final class me/kpavlov/kt/schema/generator/core/ir/Discriminator {
 }
 
 public final class me/kpavlov/kt/schema/generator/core/ir/EnumNode : me/kpavlov/kt/schema/generator/core/ir/NamedTypeNode {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;
-	public static synthetic fun copy$default (Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;
+	public static synthetic fun copy$default (Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lme/kpavlov/kt/schema/generator/core/ir/EnumNode;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
 	public final fun getEntries ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
@@ -109,8 +111,11 @@ public final class me/kpavlov/kt/schema/generator/core/ir/EnumNode : me/kpavlov/
 
 public final class me/kpavlov/kt/schema/generator/core/ir/Introspections {
 	public static final field INSTANCE Lme/kpavlov/kt/schema/generator/core/ir/Introspections;
+	public static final fun getDefaultValueFromAnnotation (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public static final fun getDescriptionFromAnnotation (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 	public static final fun getNameOverride (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+	public static final fun isEnumDefaultAnnotation (Ljava/lang/String;Ljava/lang/String;)Z
+	public static synthetic fun isEnumDefaultAnnotation$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Z
 	public static final fun isIgnoreAnnotation (Ljava/lang/String;Ljava/lang/String;)Z
 	public static synthetic fun isIgnoreAnnotation$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Z
 	public static final fun isNullableAnnotation (Ljava/lang/String;Ljava/lang/String;)Z

--- a/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
+++ b/kt-schema-generator-core/api/kt-schema-generator-core.klib.api
@@ -163,8 +163,10 @@ final class me.kpavlov.kt.schema.generator.core.ir/Discriminator { // me.kpavlov
 }
 
 final class me.kpavlov.kt.schema.generator.core.ir/EnumNode : me.kpavlov.kt.schema.generator.core.ir/NamedTypeNode { // me.kpavlov.kt.schema.generator.core.ir/EnumNode|null[0]
-    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>, kotlin/String? = ...) // me.kpavlov.kt.schema.generator.core.ir/EnumNode.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?){}[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>, kotlin/String? = ..., kotlin/String? = ...) // me.kpavlov.kt.schema.generator.core.ir/EnumNode.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?;kotlin.String?){}[0]
 
+    final val defaultValue // me.kpavlov.kt.schema.generator.core.ir/EnumNode.defaultValue|{}defaultValue[0]
+        final fun <get-defaultValue>(): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/EnumNode.defaultValue.<get-defaultValue>|<get-defaultValue>(){}[0]
     final val description // me.kpavlov.kt.schema.generator.core.ir/EnumNode.description|{}description[0]
         final fun <get-description>(): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/EnumNode.description.<get-description>|<get-description>(){}[0]
     final val entries // me.kpavlov.kt.schema.generator.core.ir/EnumNode.entries|{}entries[0]
@@ -175,7 +177,8 @@ final class me.kpavlov.kt.schema.generator.core.ir/EnumNode : me.kpavlov.kt.sche
     final fun component1(): kotlin/String // me.kpavlov.kt.schema.generator.core.ir/EnumNode.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/String> // me.kpavlov.kt.schema.generator.core.ir/EnumNode.component2|component2(){}[0]
     final fun component3(): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/EnumNode.component3|component3(){}[0]
-    final fun copy(kotlin/String = ..., kotlin.collections/List<kotlin/String> = ..., kotlin/String? = ...): me.kpavlov.kt.schema.generator.core.ir/EnumNode // me.kpavlov.kt.schema.generator.core.ir/EnumNode.copy|copy(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?){}[0]
+    final fun component4(): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/EnumNode.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<kotlin/String> = ..., kotlin/String? = ..., kotlin/String? = ...): me.kpavlov.kt.schema.generator.core.ir/EnumNode // me.kpavlov.kt.schema.generator.core.ir/EnumNode.copy|copy(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?;kotlin.String?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/EnumNode.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // me.kpavlov.kt.schema.generator.core.ir/EnumNode.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // me.kpavlov.kt.schema.generator.core.ir/EnumNode.toString|toString(){}[0]
@@ -367,8 +370,10 @@ final value class me.kpavlov.kt.schema.generator.core.ir/TypeId { // me.kpavlov.
 }
 
 final object me.kpavlov.kt.schema.generator.core.ir/Introspections { // me.kpavlov.kt.schema.generator.core.ir/Introspections|null[0]
+    final fun getDefaultValueFromAnnotation(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/Introspections.getDefaultValueFromAnnotation|getDefaultValueFromAnnotation(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
     final fun getDescriptionFromAnnotation(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/Introspections.getDescriptionFromAnnotation|getDescriptionFromAnnotation(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
     final fun getNameOverride(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // me.kpavlov.kt.schema.generator.core.ir/Introspections.getNameOverride|getNameOverride(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
+    final fun isEnumDefaultAnnotation(kotlin/String, kotlin/String? = ...): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/Introspections.isEnumDefaultAnnotation|isEnumDefaultAnnotation(kotlin.String;kotlin.String?){}[0]
     final fun isIgnoreAnnotation(kotlin/String, kotlin/String? = ...): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/Introspections.isIgnoreAnnotation|isIgnoreAnnotation(kotlin.String;kotlin.String?){}[0]
     final fun isNullableAnnotation(kotlin/String, kotlin/String? = ...): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/Introspections.isNullableAnnotation|isNullableAnnotation(kotlin.String;kotlin.String?){}[0]
     final fun isNullableTypeName(kotlin/String?): kotlin/Boolean // me.kpavlov.kt.schema.generator.core.ir/Introspections.isNullableTypeName|isNullableTypeName(kotlin.String?){}[0]

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.kt
@@ -266,4 +266,44 @@ internal expect object Config {
      * `required`.
      */
     val optionalTypeNamePatterns: List<String>
+
+    /**
+     * Annotation names recognized as enum-default-value markers (e.g. Jackson's
+     * `@JsonEnumDefaultValue`), placed on a single enum constant to mark it as that enum type's
+     * default value — emitted as the `default` keyword on the enum's own schema.
+     *
+     * Matching follows the same rules as [nameAnnotationNames]: simple names case-insensitive,
+     * FQNs (containing a dot) case-sensitive.
+     *
+     * Loaded lazily from the `introspector.annotations.enumDefault.names` property in
+     * `kt-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+     */
+    val enumDefaultAnnotationNames: List<String>
+
+    /**
+     * Annotation names recognized as default-value providers (e.g. Jackson's
+     * `@JsonProperty(defaultValue = "...")`), primarily useful for front ends without native
+     * default-value support (e.g. APT, KSP) — for reflection, a real Kotlin default value always
+     * takes precedence when both are present.
+     *
+     * Matching follows the same rules as [nameAnnotationNames].
+     *
+     * Loaded lazily from the `introspector.annotations.defaultValue.names` property in
+     * `kt-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: com.fasterxml.jackson.annotation.JsonProperty
+     */
+    val defaultValueAnnotationNames: List<String>
+
+    /**
+     * Ordered list of lowercase annotation parameter names that may contain default-value text.
+     *
+     * Loaded lazily from the `introspector.annotations.defaultValue.attributes` property in
+     * `kt-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: defaultValue
+     */
+    val defaultValueAttributes: List<String>
 }

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/Introspections.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/Introspections.kt
@@ -63,6 +63,7 @@ import kotlin.jvm.JvmStatic
  * @see Config
  */
 @InternalSchemaGeneratorApi
+@Suppress("TooManyFunctions") // one recognition function per annotation category, by design
 public object Introspections {
     //region Annotation name patterns
 
@@ -165,6 +166,25 @@ public object Introspections {
     private val optionalTypeNamePatterns: List<Regex> by lazy {
         Config.optionalTypeNamePatterns.map(::globToRegex)
     }
+
+    //endregion
+
+    //region Enum default / default value config
+
+    private val enumDefaultNames: AnnotationNamePatterns by lazy {
+        splitByFqn(Config.enumDefaultAnnotationNames)
+    }
+
+    private val defaultValueNames: AnnotationNamePatterns by lazy {
+        splitByFqn(Config.defaultValueAnnotationNames)
+    }
+
+    /**
+     * Ordered list of lowercase annotation parameter names that may contain default-value text.
+     *
+     * @see Config.defaultValueAttributes
+     */
+    private val defaultValueAttributes: List<String> = Config.defaultValueAttributes
 
     //endregion
 
@@ -302,6 +322,50 @@ public object Introspections {
     @JvmStatic
     public fun isOptionalTypeName(simpleName: String?): Boolean =
         simpleName != null && optionalTypeNamePatterns.any { it.matches(simpleName) }
+
+    /**
+     * Checks whether the given annotation is recognized as an enum-default-value marker
+     * (e.g. Jackson's `@JsonEnumDefaultValue`), placed on a single enum constant to mark it as
+     * that enum type's default value.
+     *
+     * Simple annotation names are matched **case-insensitively**; fully qualified names are matched
+     * **case-sensitively** (exact match).
+     *
+     * @param simpleName The simple name of the annotation (e.g., "JsonEnumDefaultValue")
+     * @param qualifiedName The fully qualified name of the annotation, or null if unavailable
+     * @return `true` if the annotation is recognized as an enum-default-value marker
+     */
+    @JvmStatic
+    public fun isEnumDefaultAnnotation(
+        simpleName: String,
+        qualifiedName: String? = null,
+    ): Boolean = matchesAnnotation(simpleName, qualifiedName, enumDefaultNames)
+
+    /**
+     * Extracts the default-value text from an annotation if it matches a recognized
+     * default-value annotation (e.g., `@JsonProperty(defaultValue = "...")`).
+     *
+     * Simple annotation names are matched **case-insensitively**; fully qualified names are matched
+     * **case-sensitively** (exact match).
+     *
+     * @param simpleName The simple name of the annotation (e.g., "JsonProperty")
+     * @param qualifiedName The fully qualified name of the annotation
+     *   (e.g., "com.fasterxml.jackson.annotation.JsonProperty"), or null if unavailable
+     * @param annotationArguments List of key-value pairs representing the annotation's parameters
+     * @return The default value if found, or null if the annotation is not recognized or
+     *         contains no matching default-value parameter
+     */
+    @JvmStatic
+    public fun getDefaultValueFromAnnotation(
+        simpleName: String,
+        qualifiedName: String?,
+        annotationArguments: List<Pair<String, Any?>>,
+    ): String? =
+        if (matchesAnnotation(simpleName, qualifiedName, defaultValueNames)) {
+            extractFirstStringAttribute(annotationArguments, defaultValueAttributes)
+        } else {
+            null
+        }
 
     /**
      * Extracts the first non-empty string value from annotation arguments whose key matches

--- a/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/TypeGraph.kt
+++ b/kt-schema-generator-core/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/core/ir/TypeGraph.kt
@@ -79,6 +79,7 @@ public data class PrimitiveNode(
 public data class EnumNode(
     override val name: String,
     val entries: List<String>,
+    val defaultValue: String? = null,
     override val description: String? = null,
 ) : NamedTypeNode
 

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.jvm.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.jvm.kt
@@ -18,6 +18,9 @@ private const val NULLABLE_ANNOTATION_NAMES_KEY = "introspector.annotations.null
 private const val NULLABLE_TYPE_NAMES_KEY = "introspector.nullable.type.names"
 private const val OPTIONAL_ANNOTATION_NAMES_KEY = "introspector.annotations.optional.names"
 private const val OPTIONAL_TYPE_NAMES_KEY = "introspector.optional.type.names"
+private const val ENUM_DEFAULT_NAMES_KEY = "introspector.annotations.enumDefault.names"
+private const val DEFAULT_VALUE_NAMES_KEY = "introspector.annotations.defaultValue.names"
+private const val DEFAULT_VALUE_ATTRIBUTES_KEY = "introspector.annotations.defaultValue.attributes"
 
 /**
  * Default fallback values if configuration loading fails
@@ -83,6 +86,30 @@ private val DEFAULT_NULLABLE_ANNOTATION_NAMES =
 private val DEFAULT_NULLABLE_TYPE_PATTERNS =
     listOf(
         "*Opt",
+    )
+
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_ENUM_DEFAULT_ANNOTATION_NAMES =
+    listOf(
+        "com.fasterxml.jackson.annotation.JsonEnumDefaultValue",
+    )
+
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_DEFAULT_VALUE_ANNOTATION_NAMES =
+    listOf(
+        "com.fasterxml.jackson.annotation.JsonProperty",
+    )
+
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_DEFAULT_VALUE_ATTRIBUTES =
+    listOf(
+        "defaultValue",
     )
 
 private val logger = KotlinLogging.logger {}
@@ -174,6 +201,24 @@ internal actual object Config {
         loadConfiguration { properties ->
             parseListPropertyPreservingCase(properties, OPTIONAL_TYPE_NAMES_KEY, allowEmpty = true)
         } ?: emptyList()
+    }
+
+    actual val enumDefaultAnnotationNames: List<String> by lazy {
+        loadConfiguration { properties ->
+            parseListPropertyPreservingFqnCase(properties, ENUM_DEFAULT_NAMES_KEY)
+        } ?: DEFAULT_ENUM_DEFAULT_ANNOTATION_NAMES
+    }
+
+    actual val defaultValueAnnotationNames: List<String> by lazy {
+        loadConfiguration { properties ->
+            parseListPropertyPreservingFqnCase(properties, DEFAULT_VALUE_NAMES_KEY)
+        } ?: DEFAULT_DEFAULT_VALUE_ANNOTATION_NAMES
+    }
+
+    actual val defaultValueAttributes: List<String> by lazy {
+        loadConfiguration { properties ->
+            parseListProperty(properties, DEFAULT_VALUE_ATTRIBUTES_KEY)
+        } ?: DEFAULT_DEFAULT_VALUE_ATTRIBUTES
     }
 
     private fun <T> loadConfiguration(extractor: (Properties) -> T): T? =

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -282,14 +282,18 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
     private fun createEnumNode(klass: KClass<*>): EnumNode {
         @Suppress("UNCHECKED_CAST")
         val enumConstants = (klass.java as Class<out Enum<*>>).enumConstants
+        var defaultValue: String? = null
         val entries = enumConstants.map { constant ->
-            val field = klass.java.getField(constant.name)
-            extractNameOverride(field.annotations.toList()) ?: constant.name
+            val annotations = klass.java.getField(constant.name).annotations.toList()
+            val entryName = extractNameOverride(annotations) ?: constant.name
+            if (defaultValue == null && isEnumDefaultAnnotated(annotations)) defaultValue = entryName
+            entryName
         }
         val nameOverride = extractNameOverride(klass.java.annotations.toList())
         return EnumNode(
             name = nameOverride ?: klass.qualifiedName ?: klass.simpleName ?: "UnknownEnum",
             entries = entries,
+            defaultValue = defaultValue,
             description = extractDescription(klass.java.annotations.toList()),
         )
     }
@@ -429,8 +433,10 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 if (isNullableAnnotated(annotations)) it.withNullable(true) else it
             }
         val fixedValue = defaultValues[property.name]
+        val annotationDefault = extractDefaultValueOverride(annotations)
         val hasDefaultValue =
             fixedValue != null ||
+                annotationDefault != null ||
                 isOptionalTypeName(property.returnType.klass) ||
                 isOptionalAnnotated(annotations)
         return Property(
@@ -438,7 +444,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             type = typeRef,
             description = extractDescription(annotations) ?: fallbackDescription,
             hasDefaultValue = hasDefaultValue,
-            defaultValue = fixedValue,
+            defaultValue = fixedValue ?: annotationDefault,
             isConstant = fixedValue != null,
         )
     }
@@ -525,17 +531,22 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                     if (isNullableAnnotated(annotations)) it.withNullable(true) else it
                 }
 
+            // Real Kotlin default value takes precedence; fall back to an annotation-provided
+            // default (e.g. `@JsonProperty(defaultValue = "...")`) when there is no real value —
+            // mainly matters for front ends without native default-value support.
+            val annotationDefault = extractDefaultValueOverride(annotations)
+            val defaultValue = (if (param.isOptional) defaultValues[kotlinName] else null) ?: annotationDefault
+
             // A property is optional (excluded from `required`) when it has a Kotlin default
-            // value, or when it's marked nullable/optional by convention (type-name pattern or
-            // `@Nullable`-style annotation) — the latter mainly matters for front ends without
-            // native default-value support, but applies uniformly here for consistency.
+            // value, a known default value, or when it's marked nullable/optional by convention
+            // (type-name pattern or `@Nullable`-style annotation) — the latter mainly matters for
+            // front ends without native default-value support, but applies uniformly here for
+            // consistency.
             val hasDefault =
                 param.isOptional ||
+                    annotationDefault != null ||
                     isOptionalTypeName(propertyType.klass) ||
                     isOptionalAnnotated(annotations)
-
-            // Get the actual default value if available
-            val defaultValue = if (param.isOptional) defaultValues[kotlinName] else null
 
             properties +=
                 Property(

--- a/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
+++ b/kt-schema-generator-core/src/jvmMain/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionUtils.kt
@@ -112,6 +112,36 @@ public fun extractNameOverride(annotations: List<Annotation>): String? =
     }
 
 /**
+ * Checks whether the given list of annotations contains a recognized enum-default-value marker
+ * (e.g., `@JsonEnumDefaultValue`), placed on a single enum constant.
+ *
+ * @see [Introspections.isEnumDefaultAnnotation]
+ */
+internal fun isEnumDefaultAnnotated(annotations: List<Annotation>): Boolean =
+    annotations.any { annotation ->
+        val javaClass = annotation.annotationClass.java
+        Introspections.isEnumDefaultAnnotation(javaClass.simpleName, javaClass.name)
+    }
+
+/**
+ * Extracts a default-value override from annotations (e.g., from `@JsonProperty(defaultValue = "...")`).
+ *
+ * Mainly useful for front ends without native default-value support; for reflection, a real
+ * Kotlin default value always takes precedence when both are present.
+ *
+ * @see [Introspections.getDefaultValueFromAnnotation]
+ */
+internal fun extractDefaultValueOverride(annotations: List<Annotation>): String? =
+    annotations.firstNotNullOfOrNull { annotation ->
+        val javaClass = annotation.annotationClass.java
+        Introspections.getDefaultValueFromAnnotation(
+            javaClass.simpleName,
+            javaClass.name,
+            buildAnnotationArgs(annotation),
+        )
+    }
+
+/**
  * Builds key-value pairs from an annotation's elements for use with [Introspections] methods.
  *
  * Uses Java reflection via [Class.getDeclaredMethods] to reliably access annotation elements,

--- a/kt-schema-generator-core/src/jvmMain/resources/kt-schema.properties
+++ b/kt-schema-generator-core/src/jvmMain/resources/kt-schema.properties
@@ -98,6 +98,37 @@ introspector.annotations.optional.names=
 ## explicitly if you want this convention.
 introspector.optional.type.names=
 
+## Annotation names recognized as enum-default-value markers, placed on a single enum constant to
+## mark it as that enum type's default value — emitted as the `default` keyword on the enum's own
+## schema (so every property referencing that enum inherits it via `$ref`).
+## Names containing a dot are treated as fully qualified names (FQN) glob patterns and matched
+## case-sensitively. Names without a dot are simple-name glob patterns matched case-insensitively.
+##
+## Default annotations supported:
+## - com.fasterxml.jackson.annotation.JsonEnumDefaultValue (Jackson, matched by FQN)
+##
+## Note: kotlinx.serialization has no equivalent annotation. Even a plain Jackson annotation placed
+## on an enum entry is invisible to the kotlinx.serialization-based introspector, since
+## SerialDescriptor only preserves annotations meta-annotated with `@SerialInfo` — this property
+## does not apply to that front end.
+introspector.annotations.enumDefault.names=com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+
+## Annotation names recognized as default-value providers (e.g. Jackson's documented
+## schema-metadata attribute `@JsonProperty(defaultValue = "...")`). Populates a property's default
+## value in the emitted schema — mainly useful for front ends without native default-value support
+## (APT, KSP); for reflection, a real Kotlin default value always takes precedence when both are
+## present.
+## Names containing a dot are treated as fully qualified names (FQN) glob patterns and matched
+## case-sensitively. Names without a dot are simple-name glob patterns matched case-insensitively.
+##
+## Default annotations supported:
+## - com.fasterxml.jackson.annotation.JsonProperty (Jackson, matched by FQN)
+introspector.annotations.defaultValue.names=com.fasterxml.jackson.annotation.JsonProperty
+
+## Annotation parameter names that contain default-value text (exact names, not glob patterns)
+## Format: Comma-separated list (case-insensitive matching)
+introspector.annotations.defaultValue.attributes=defaultValue
+
 ## Fully qualified class names of types to treat as opaque JSON values
 ## These types are mapped to `{}` (empty schema) during reflection-based introspection
 ## instead of being processed through standard object or sealed-type pipelines.

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ConfigTest.kt
@@ -69,4 +69,15 @@ class ConfigTest {
     fun `loads nullable type name patterns from properties preserving case`() {
         Config.nullableTypeNamePatterns shouldContain "*Opt"
     }
+
+    @Test
+    fun `loads enum default annotation names from properties`() {
+        Config.enumDefaultAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonEnumDefaultValue"
+    }
+
+    @Test
+    fun `loads default value annotation names and attributes from properties`() {
+        Config.defaultValueAnnotationNames shouldContain "com.fasterxml.jackson.annotation.JsonProperty"
+        Config.defaultValueAttributes shouldContain "defaultvalue"
+    }
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ir/IntrospectionsTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/core/ir/IntrospectionsTest.kt
@@ -301,4 +301,81 @@ class IntrospectionsTest {
     }
 
     //endregion
+
+    //region Enum default annotation recognition
+
+    @Test
+    fun `recognizes JsonEnumDefaultValue by FQN as enum default marker`() {
+        Introspections.isEnumDefaultAnnotation(
+            simpleName = "JsonEnumDefaultValue",
+            qualifiedName = "com.fasterxml.jackson.annotation.JsonEnumDefaultValue",
+        ) shouldBe true
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "JsonEnumDefaultValue, com.example.JsonEnumDefaultValue",
+        "SomeOtherAnnotation, com.fasterxml.jackson.annotation.SomeOtherAnnotation",
+        "JsonEnumDefaultValue, ",
+    )
+    fun `does not match unrecognized annotations as enum default marker`(
+        simpleName: String,
+        qualifiedName: String?,
+    ) {
+        Introspections.isEnumDefaultAnnotation(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName?.takeIf { it.isNotEmpty() },
+        ) shouldBe false
+    }
+
+    //endregion
+
+    //region Default value annotation extraction
+
+    @ParameterizedTest
+    @CsvSource(
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonProperty, ACTIVE, ACTIVE",
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonProperty, 30, 30",
+    )
+    fun `getDefaultValueFromAnnotation extracts defaultValue attribute when FQN matches`(
+        simpleName: String,
+        qualifiedName: String,
+        inputValue: String,
+        expectedResult: String,
+    ) {
+        Introspections.getDefaultValueFromAnnotation(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
+            annotationArguments = listOf("defaultValue" to inputValue),
+        ) shouldBe expectedResult
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "JsonProperty, JsonProperty, ACTIVE",
+        "JsonProperty, com.fasterxml.jackson.annotation.JsonPropertyDescription, ACTIVE",
+        "SomeOther, com.example.SomeOther, ACTIVE",
+    )
+    fun `getDefaultValueFromAnnotation returns null for non-matching cases`(
+        simpleName: String,
+        qualifiedName: String,
+        inputValue: String,
+    ) {
+        Introspections.getDefaultValueFromAnnotation(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
+            annotationArguments = listOf("defaultValue" to inputValue),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `getDefaultValueFromAnnotation returns null when defaultValue attribute is empty`() {
+        Introspections.getDefaultValueFromAnnotation(
+            simpleName = "JsonProperty",
+            qualifiedName = "com.fasterxml.jackson.annotation.JsonProperty",
+            annotationArguments = listOf("defaultValue" to ""),
+        ) shouldBe null
+    }
+
+    //endregion
 }

--- a/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorJacksonTest.kt
+++ b/kt-schema-generator-core/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/reflect/ReflectionIntrospectorJacksonTest.kt
@@ -1,5 +1,6 @@
 package me.kpavlov.kt.schema.generator.reflect
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
@@ -9,6 +10,7 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import me.kpavlov.kt.schema.generator.core.ir.AnyNode
+import me.kpavlov.kt.schema.generator.core.ir.EnumNode
 import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
 import me.kpavlov.kt.schema.generator.core.ir.PolymorphicNode
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
@@ -126,6 +128,30 @@ class ReflectionIntrospectorJacksonTest {
         val label: String,
     ) : JacksonRecord()
 
+    @Suppress("unused")
+    enum class Priority {
+        LOW,
+
+        @JsonEnumDefaultValue
+        MEDIUM,
+        HIGH,
+    }
+
+    @Suppress("unused")
+    data class WithEnumDefault(
+        val priority: Priority,
+    )
+
+    @Suppress("unused")
+    data class WithAnnotationDefault(
+        @param:JsonProperty(defaultValue = "30") val timeout: Int,
+    )
+
+    @Suppress("unused")
+    data class WithRealDefaultPrecedence(
+        @param:JsonProperty(defaultValue = "IGNORED") val label: String = "REAL",
+    )
+
     private val introspector = ReflectionClassIntrospector
 
     @Test
@@ -235,6 +261,41 @@ class ReflectionIntrospectorJacksonTest {
 
         node.properties.map { it.name } shouldNotContain "internalToken"
         node.required shouldNotContain "internalToken"
+    }
+
+    @Test
+    fun `introspects enum default value from JsonEnumDefaultValue annotation`() {
+        val graph = introspector.introspect(WithEnumDefault::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+        val priorityRef = node.properties.first { it.name == "priority" }.type.shouldBeInstanceOf<TypeRef.Ref>()
+        val enumNode = graph.nodes[priorityRef.id].shouldBeInstanceOf<EnumNode>()
+
+        enumNode.defaultValue shouldBe "MEDIUM"
+    }
+
+    @Test
+    fun `populates property default value from JsonProperty defaultValue annotation`() {
+        val graph = introspector.introspect(WithAnnotationDefault::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+        val timeoutProp = node.properties.first { it.name == "timeout" }
+
+        timeoutProp.hasDefaultValue shouldBe true
+        timeoutProp.defaultValue shouldBe "30"
+        node.required shouldNotContain "timeout"
+    }
+
+    @Test
+    fun `real Kotlin default value takes precedence over JsonProperty defaultValue annotation`() {
+        val graph = introspector.introspect(WithRealDefaultPrecedence::class)
+
+        val root = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val node = graph.nodes[root.id].shouldBeInstanceOf<ObjectNode>()
+
+        node.properties.first { it.name == "label" }.defaultValue shouldBe "REAL"
     }
 
     //region Jackson databind node types

--- a/kt-schema-generator-core/src/nativeMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.native.kt
+++ b/kt-schema-generator-core/src/nativeMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.native.kt
@@ -21,4 +21,10 @@ internal actual object Config {
         get() = emptyList()
     actual val optionalTypeNamePatterns: List<String>
         get() = emptyList()
+    actual val enumDefaultAnnotationNames: List<String>
+        get() = listOf("com.fasterxml.jackson.annotation.JsonEnumDefaultValue")
+    actual val defaultValueAnnotationNames: List<String>
+        get() = listOf("com.fasterxml.jackson.annotation.JsonProperty")
+    actual val defaultValueAttributes: List<String>
+        get() = listOf("defaultValue")
 }

--- a/kt-schema-generator-core/src/webMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.web.kt
+++ b/kt-schema-generator-core/src/webMain/kotlin/me/kpavlov/kt/schema/generator/core/Config.web.kt
@@ -21,4 +21,10 @@ internal actual object Config {
         get() = emptyList()
     actual val optionalTypeNamePatterns: List<String>
         get() = emptyList()
+    actual val enumDefaultAnnotationNames: List<String>
+        get() = listOf("com.fasterxml.jackson.annotation.JsonEnumDefaultValue")
+    actual val defaultValueAnnotationNames: List<String>
+        get() = listOf("com.fasterxml.jackson.annotation.JsonProperty")
+    actual val defaultValueAttributes: List<String>
+        get() = listOf("defaultValue")
 }

--- a/kt-schema-generator-json/build.gradle.kts
+++ b/kt-schema-generator-json/build.gradle.kts
@@ -34,6 +34,8 @@ kotlin {
                 implementation(libs.junit.pioneer)
                 implementation(libs.junit.jupiter.params)
                 implementation(libs.mockk)
+                implementation(dependencies.platform(libs.jackson.bom))
+                implementation(libs.jackson.annotations)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtils.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtils.kt
@@ -10,6 +10,7 @@ import me.kpavlov.kt.schema.json.BooleanPropertyDefinition
 import me.kpavlov.kt.schema.json.BooleanSchemaDefinition
 import me.kpavlov.kt.schema.json.GenericPropertyDefinition
 import me.kpavlov.kt.schema.json.JsonSchema
+import me.kpavlov.kt.schema.json.JsonSchemaConstants.Types.NUMBER
 import me.kpavlov.kt.schema.json.NumericPropertyDefinition
 import me.kpavlov.kt.schema.json.ObjectPropertyDefinition
 import me.kpavlov.kt.schema.json.OneOfPropertyDefinition
@@ -22,6 +23,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.jvm.JvmName
+import kotlin.math.floor
 
 /**
  * Sets the const value on a property definition.
@@ -68,8 +70,10 @@ internal fun setDefaultValue(
  * isn't emitted as a JSON string next to a numeric/boolean `type`. Values that are already
  * natively typed (e.g. a real Kotlin default obtained via reflection) pass through unchanged.
  *
- * Falls back to the original string when it doesn't parse as the target type, so the default is
- * still shown (in the wrong shape) rather than silently dropped.
+ * @throws IllegalArgumentException if the string doesn't match [propertyDef]'s declared type,
+ * e.g. `"3.14"` on an `integer` property or `"maybe"` on a `boolean` property. A whole-number
+ * decimal string such as `"30.0"` is accepted for `integer` properties, per the JSON Schema
+ * rule that any zero-fractional-part number satisfies `type: integer`.
  */
 private fun coerceToDeclaredType(
     propertyDef: PropertyDefinition,
@@ -77,9 +81,33 @@ private fun coerceToDeclaredType(
 ): Any? {
     if (value !is String) return value
     return when (propertyDef) {
-        is NumericPropertyDefinition -> value.toLongOrNull() ?: value.toDoubleOrNull() ?: value
-        is BooleanPropertyDefinition -> value.toBooleanStrictOrNull() ?: value
+        is NumericPropertyDefinition -> coerceNumericDefault(propertyDef, value)
+        is BooleanPropertyDefinition ->
+            requireNotNull(value.toBooleanStrictOrNull()) {
+                "Annotation default '$value' is not a valid boolean for type ${propertyDef.type}"
+            }
         else -> value
+    }
+}
+
+private fun coerceNumericDefault(
+    propertyDef: NumericPropertyDefinition,
+    value: String,
+): Number {
+    val long = value.toLongOrNull()
+    if (long != null) return long
+
+    val double =
+        requireNotNull(value.toDoubleOrNull()?.takeIf { it.isFinite() }) {
+            "Annotation default '$value' is not a valid number for type ${propertyDef.type}"
+        }
+    return if (NUMBER in propertyDef.type) {
+        double
+    } else {
+        require(double == floor(double)) {
+            "Annotation default '$value' is not a valid integer for type ${propertyDef.type}"
+        }
+        double.toLong()
     }
 }
 

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtils.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtils.kt
@@ -2,6 +2,7 @@
 
 package me.kpavlov.kt.schema.generator.json
 
+import me.kpavlov.kt.schema.generator.core.ir.Property
 import me.kpavlov.kt.schema.json.AllOfPropertyDefinition
 import me.kpavlov.kt.schema.json.AnyOfPropertyDefinition
 import me.kpavlov.kt.schema.json.ArrayPropertyDefinition
@@ -47,7 +48,7 @@ internal fun setDefaultValue(
     propertyDef: PropertyDefinition,
     defaultValue: Any?,
 ): PropertyDefinition {
-    val jsonElement = toJsonElement(defaultValue) ?: return propertyDef
+    val jsonElement = toJsonElement(coerceToDeclaredType(propertyDef, defaultValue)) ?: return propertyDef
 
     return when (propertyDef) {
         is StringPropertyDefinition -> propertyDef.copy(default = jsonElement)
@@ -55,9 +56,50 @@ internal fun setDefaultValue(
         is BooleanPropertyDefinition -> propertyDef.copy(default = jsonElement)
         is ArrayPropertyDefinition -> propertyDef.copy(default = jsonElement)
         is ObjectPropertyDefinition -> propertyDef.copy(default = jsonElement)
+        is ReferencePropertyDefinition -> propertyDef.copy(default = jsonElement)
+        is OneOfPropertyDefinition -> propertyDef.copy(default = jsonElement)
         else -> propertyDef
     }
 }
+
+/**
+ * Coerces an annotation-sourced default value — always a raw `String`, e.g. from
+ * `@JsonProperty(defaultValue = "30")` — to match [propertyDef]'s declared JSON type, so `default`
+ * isn't emitted as a JSON string next to a numeric/boolean `type`. Values that are already
+ * natively typed (e.g. a real Kotlin default obtained via reflection) pass through unchanged.
+ *
+ * Falls back to the original string when it doesn't parse as the target type, so the default is
+ * still shown (in the wrong shape) rather than silently dropped.
+ */
+private fun coerceToDeclaredType(
+    propertyDef: PropertyDefinition,
+    value: Any?,
+): Any? {
+    if (value !is String) return value
+    return when (propertyDef) {
+        is NumericPropertyDefinition -> value.toLongOrNull() ?: value.toDoubleOrNull() ?: value
+        is BooleanPropertyDefinition -> value.toBooleanStrictOrNull() ?: value
+        else -> value
+    }
+}
+
+/**
+ * Applies a property's constant or default value to its definition, if applicable.
+ *
+ * A constant property gets its value emitted via `const`; a non-required property with a known
+ * default value gets it emitted via `default`. Shared by both the plain JSON Schema and function
+ * calling transformers.
+ */
+internal fun applyDefaultOrConst(
+    propertyDef: PropertyDefinition,
+    property: Property,
+    isRequired: Boolean,
+): PropertyDefinition =
+    when {
+        property.isConstant -> setConstValue(propertyDef, property.defaultValue)
+        !isRequired && property.defaultValue != null -> setDefaultValue(propertyDef, property.defaultValue)
+        else -> propertyDef
+    }
 
 /**
  * Sets the description on a property definition, if [PropertyDefinition] supports it.

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
@@ -127,24 +127,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
                     val finalDef =
                         convertTypeRef(property.type, graph, jsonTypeNames, depth = 0)
                             .let { def -> property.description?.let { setDescription(def, it) } ?: def }
-                            .let { def ->
-                                when {
-                                    property.isConstant -> {
-                                        setConstValue(def, property.defaultValue)
-                                    }
-
-                                    !isRequired && property.defaultValue != null -> {
-                                        setDefaultValue(
-                                            def,
-                                            property.defaultValue,
-                                        )
-                                    }
-
-                                    else -> {
-                                        def
-                                    }
-                                }
-                            }
+                            .let { def -> applyDefaultOrConst(def, property, isRequired) }
                     property.name to finalDef
                 }
 
@@ -332,24 +315,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
                     val finalDef =
                         convertTypeRef(property.type, graph, jsonTypeNames, depth)
                             .let { def -> property.description?.let { setDescription(def, it) } ?: def }
-                            .let { def ->
-                                when {
-                                    property.isConstant -> {
-                                        setConstValue(def, property.defaultValue)
-                                    }
-
-                                    !isRequired && property.defaultValue != null -> {
-                                        setDefaultValue(
-                                            def,
-                                            property.defaultValue,
-                                        )
-                                    }
-
-                                    else -> {
-                                        def
-                                    }
-                                }
-                            }
+                            .let { def -> applyDefaultOrConst(def, property, isRequired) }
                     property.name to finalDef
                 }
 
@@ -366,13 +332,21 @@ public class TypeGraphToFunctionCallingSchemaTransformer
         private fun convertEnum(
             node: EnumNode,
             nullable: Boolean,
-        ): PropertyDefinition =
-            StringPropertyDefinition(
-                type = if (nullable) STRING_OR_NULL_TYPE else STRING_TYPE,
-                description = node.description,
-                nullable = null,
-                enum = node.entries,
-            )
+        ): PropertyDefinition {
+            val base =
+                StringPropertyDefinition(
+                    type = if (nullable) STRING_OR_NULL_TYPE else STRING_TYPE,
+                    description = node.description,
+                    nullable = null,
+                    enum = node.entries,
+                )
+            // OpenAI structured-output strict mode disallows the "default" keyword entirely.
+            return if (config.strictMode) {
+                base
+            } else {
+                node.defaultValue?.let { setDefaultValue(base, it) } ?: base
+            }
+        }
 
         private fun convertList(
             node: ListNode,

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
@@ -484,20 +484,7 @@ public class TypeGraphToJsonSchemaTransformer
                             propertyDef
                         }
 
-                    val withDefaultOrConst =
-                        when {
-                            property.isConstant -> {
-                                setConstValue(withoutNullableIfRequired, property.defaultValue)
-                            }
-
-                            !isRequired && property.defaultValue != null -> {
-                                setDefaultValue(withoutNullableIfRequired, property.defaultValue)
-                            }
-
-                            else -> {
-                                withoutNullableIfRequired
-                            }
-                        }
+                    val withDefaultOrConst = applyDefaultOrConst(withoutNullableIfRequired, property, isRequired)
 
                     // Add description if available
                     val finalDef =
@@ -520,13 +507,16 @@ public class TypeGraphToJsonSchemaTransformer
         private fun convertEnum(
             node: EnumNode,
             nullable: Boolean,
-        ): PropertyDefinition =
-            StringPropertyDefinition(
-                type = if (nullable && config.useUnionTypes) STRING_OR_NULL_TYPE else STRING_TYPE,
-                description = node.description,
-                nullable = getNullableFlag(nullable),
-                enum = node.entries,
-            )
+        ): PropertyDefinition {
+            val base =
+                StringPropertyDefinition(
+                    type = if (nullable && config.useUnionTypes) STRING_OR_NULL_TYPE else STRING_TYPE,
+                    description = node.description,
+                    nullable = getNullableFlag(nullable),
+                    enum = node.entries,
+                )
+            return node.defaultValue?.let { setDefaultValue(base, it) } ?: base
+        }
 
         private fun convertList(
             node: ListNode,

--- a/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
+++ b/kt-schema-generator-json/src/commonMain/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
@@ -187,6 +187,7 @@ public class TypeGraphToJsonSchemaTransformer
                 type = rootDefinition.type,
                 `enum` = rootDefinition.enum?.map { JsonPrimitive(it) },
                 description = rootDefinition.description,
+                default = rootDefinition.default,
                 properties = emptyMap(),
                 required = emptyList(),
                 additionalProperties = null,

--- a/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
+++ b/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
@@ -555,6 +555,32 @@ class TypeGraphToJsonSchemaTransformerTest {
             }
             """.trimIndent()
     }
+
+    @Test
+    fun `root enum node default value is emitted as default on the root schema`() {
+        val statusId = TypeId("Status")
+        val statusNode = EnumNode(name = "Status", entries = listOf("ACTIVE", "INACTIVE"), defaultValue = "ACTIVE")
+        val graph =
+            TypeGraph(
+                root = TypeRef.Ref(statusId),
+                nodes = mapOf(statusId to statusNode),
+            )
+
+        val schema = transformer.transform(graph, "Status")
+        val schemaJson = schema.encodeToString(json)
+
+        schemaJson shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Status",
+              "type": "string",
+              "enum": ["ACTIVE", "INACTIVE"],
+              "default": "ACTIVE"
+            }
+            """.trimIndent()
+    }
 }
 
 private infix fun String.shouldContainAny(candidates: List<String>) {

--- a/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
+++ b/kt-schema-generator-json/src/commonTest/kotlin/me/kpavlov/kt/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import me.kpavlov.kt.schema.generator.core.ir.Discriminator
+import me.kpavlov.kt.schema.generator.core.ir.EnumNode
 import me.kpavlov.kt.schema.generator.core.ir.ObjectNode
 import me.kpavlov.kt.schema.generator.core.ir.PolymorphicNode
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
@@ -510,6 +511,49 @@ class TypeGraphToJsonSchemaTransformerTest {
         names[xId] shouldBe "com.example.X"
         names[yId] shouldBe "com.example.Y"
         names[wId] shouldBe "com.example.W"
+    }
+
+    @Test
+    fun `enum node default value is emitted as default on its own defs schema`() {
+        val statusId = TypeId("Status")
+        val statusNode = EnumNode(name = "Status", entries = listOf("ACTIVE", "INACTIVE"), defaultValue = "ACTIVE")
+        val rootId = TypeId("Root")
+        val rootNode =
+            ObjectNode(
+                name = "Root",
+                properties = listOf(Property(name = "status", type = TypeRef.Ref(statusId))),
+                required = setOf("status"),
+            )
+        val graph =
+            TypeGraph(
+                root = TypeRef.Ref(rootId),
+                nodes = mapOf(rootId to rootNode, statusId to statusNode),
+            )
+
+        val schema = transformer.transform(graph, "Root")
+        val schemaJson = schema.encodeToString(json)
+
+        schemaJson shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Root",
+              "type": "object",
+              "properties": {
+                "status": { "$ref": "#/$defs/Status" }
+              },
+              "required": ["status"],
+              "additionalProperties": false,
+              "$defs": {
+                "Status": {
+                  "type": "string",
+                  "enum": ["ACTIVE", "INACTIVE"],
+                  "default": "ACTIVE"
+                }
+              }
+            }
+            """.trimIndent()
     }
 }
 

--- a/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/JsonSchemaGeneratorTest.kt
+++ b/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/JsonSchemaGeneratorTest.kt
@@ -2,8 +2,9 @@
 
 package me.kpavlov.kt.schema.generator.json
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.kotest.assertions.json.shouldEqualJson
-import me.kpavlov.kt.schema.Description
+import kotlinx.serialization.SerialInfo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -11,6 +12,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import me.kpavlov.kt.schema.Description
 import kotlin.test.Test
 
 class JsonSchemaGeneratorTest {
@@ -71,6 +73,13 @@ class JsonSchemaGeneratorTest {
         @property:SerialDescription("Described property")
         val name: String,
         val count: Int,
+    )
+
+    data class WithAnnotationDefaults(
+        @param:JsonProperty(defaultValue = "30")
+        val timeoutSeconds: Int,
+        @param:JsonProperty(defaultValue = "true")
+        val enabled: Boolean,
     )
 
     @Serializable
@@ -172,7 +181,8 @@ class JsonSchemaGeneratorTest {
                   "description": "A custom polymorphic property"
                 },
                 "enumProperty": {
-                  "$ref": "#/$defs/me.kpavlov.kt.schema.generator.json.JsonSchemaGeneratorTest.TestEnum"
+                  "$ref": "#/$defs/me.kpavlov.kt.schema.generator.json.JsonSchemaGeneratorTest.TestEnum",
+                  "default": "One"
                 },
                 "objectProperty": {
                   "$ref": "#/$defs/me.kpavlov.kt.schema.generator.json.JsonSchemaGeneratorTest.TestObject"
@@ -262,6 +272,26 @@ class JsonSchemaGeneratorTest {
                 "count": { "type": "integer" }
               },
               "required": ["name", "count"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `annotation-provided default value matches the property's declared JSON type`() {
+        val schema = generator.generateSchemaString(WithAnnotationDefaults::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "me.kpavlov.kt.schema.generator.json.JsonSchemaGeneratorTest.WithAnnotationDefaults",
+              "type": "object",
+              "properties": {
+                "timeoutSeconds": { "type": "integer", "default": 30 },
+                "enabled": { "type": "boolean", "default": true }
+              },
               "additionalProperties": false
             }
             """.trimIndent()

--- a/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtilsTest.kt
+++ b/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtilsTest.kt
@@ -1,6 +1,10 @@
 package me.kpavlov.kt.schema.generator.json
 
 import io.kotest.matchers.shouldBe
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
+import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
+import me.kpavlov.kt.schema.generator.core.ir.Property
+import me.kpavlov.kt.schema.generator.core.ir.TypeRef
 import me.kpavlov.kt.schema.json.AllOfPropertyDefinition
 import me.kpavlov.kt.schema.json.AnyOfPropertyDefinition
 import me.kpavlov.kt.schema.json.ArrayPropertyDefinition
@@ -20,6 +24,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -36,6 +41,74 @@ class PropertyDefinitionUtilsTest {
         setDefaultValue(boolProp, true) shouldBe boolProp.copy(default = JsonPrimitive(true))
 
         setDefaultValue(stringProp, null) shouldBe stringProp.copy(default = JsonNull)
+    }
+
+    @Test
+    fun `setDefaultValue should handle Reference and OneOf definitions`() {
+        val refProp = ReferencePropertyDefinition(ref = "#/defs/Status")
+        setDefaultValue(refProp, "ACTIVE") shouldBe refProp.copy(default = JsonPrimitive("ACTIVE"))
+
+        val oneOfProp = OneOfPropertyDefinition(oneOf = emptyList())
+        setDefaultValue(oneOfProp, "ACTIVE") shouldBe oneOfProp.copy(default = JsonPrimitive("ACTIVE"))
+    }
+
+    @Test
+    fun `setDefaultValue coerces an integer-looking annotation string to a JSON number for numeric properties`() {
+        val numProp = NumericPropertyDefinition(type = listOf("integer"))
+        setDefaultValue(numProp, "30") shouldBe numProp.copy(default = JsonPrimitive(30L))
+    }
+
+    @Test
+    fun `setDefaultValue coerces a decimal-looking annotation string to a JSON number for numeric properties`() {
+        val numProp = NumericPropertyDefinition(type = listOf("number"))
+        setDefaultValue(numProp, "3.5") shouldBe numProp.copy(default = JsonPrimitive(3.5))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "true, true",
+        "false, false",
+    )
+    fun `setDefaultValue coerces a boolean-looking annotation string to a JSON boolean for boolean properties`(
+        rawValue: String,
+        expected: Boolean,
+    ) {
+        val boolProp = BooleanPropertyDefinition()
+        setDefaultValue(boolProp, rawValue) shouldBe boolProp.copy(default = JsonPrimitive(expected))
+    }
+
+    @Test
+    fun `setDefaultValue falls back to the raw string when it does not parse as the target type`() {
+        val numProp = NumericPropertyDefinition(type = listOf("integer"))
+        setDefaultValue(numProp, "not-a-number") shouldBe numProp.copy(default = JsonPrimitive("not-a-number"))
+    }
+
+    private fun stringProperty(defaultValue: Any? = null, isConstant: Boolean = false): Property =
+        Property(
+            name = "x",
+            type = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING)),
+            defaultValue = defaultValue,
+            isConstant = isConstant,
+        )
+
+    @Test
+    fun `applyDefaultOrConst should set const value for constant properties`() {
+        val def = StringPropertyDefinition()
+        applyDefaultOrConst(def, stringProperty(defaultValue = "FIXED", isConstant = true), isRequired = true) shouldBe
+            def.copy(constValue = JsonPrimitive("FIXED"))
+    }
+
+    @Test
+    fun `applyDefaultOrConst should set default value for optional properties with a default`() {
+        val def = StringPropertyDefinition()
+        applyDefaultOrConst(def, stringProperty(defaultValue = "FALLBACK"), isRequired = false) shouldBe
+            def.copy(default = JsonPrimitive("FALLBACK"))
+    }
+
+    @Test
+    fun `applyDefaultOrConst should leave required properties without applying their default`() {
+        val def = StringPropertyDefinition()
+        applyDefaultOrConst(def, stringProperty(defaultValue = "IGNORED"), isRequired = true) shouldBe def
     }
 
     @ParameterizedTest

--- a/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtilsTest.kt
+++ b/kt-schema-generator-json/src/jvmTest/kotlin/me/kpavlov/kt/schema/generator/json/PropertyDefinitionUtilsTest.kt
@@ -1,5 +1,6 @@
 package me.kpavlov.kt.schema.generator.json
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveKind
 import me.kpavlov.kt.schema.generator.core.ir.PrimitiveNode
@@ -64,6 +65,36 @@ class PropertyDefinitionUtilsTest {
         setDefaultValue(numProp, "3.5") shouldBe numProp.copy(default = JsonPrimitive(3.5))
     }
 
+    @Test
+    fun `setDefaultValue coerces a whole-number decimal string to a JSON integer for integer properties`() {
+        val numProp = NumericPropertyDefinition(type = listOf("integer"))
+        setDefaultValue(numProp, "30.0") shouldBe numProp.copy(default = JsonPrimitive(30L))
+    }
+
+    @Test
+    fun `setDefaultValue throws when a non-integral annotation string is used for an integer property`() {
+        val numProp = NumericPropertyDefinition(type = listOf("integer"))
+        shouldThrow<IllegalArgumentException> { setDefaultValue(numProp, "3.5") }
+    }
+
+    @Test
+    fun `setDefaultValue throws when an annotation string is not a valid number`() {
+        val numProp = NumericPropertyDefinition(type = listOf("number"))
+        shouldThrow<IllegalArgumentException> { setDefaultValue(numProp, "not-a-number") }
+    }
+
+    @Test
+    fun `setDefaultValue throws when an annotation string is a non-finite number`() {
+        val numProp = NumericPropertyDefinition(type = listOf("number"))
+        shouldThrow<IllegalArgumentException> { setDefaultValue(numProp, "NaN") }
+    }
+
+    @Test
+    fun `setDefaultValue throws when an annotation string is not a valid boolean`() {
+        val boolProp = BooleanPropertyDefinition()
+        shouldThrow<IllegalArgumentException> { setDefaultValue(boolProp, "yes") }
+    }
+
     @ParameterizedTest
     @CsvSource(
         "true, true",
@@ -75,12 +106,6 @@ class PropertyDefinitionUtilsTest {
     ) {
         val boolProp = BooleanPropertyDefinition()
         setDefaultValue(boolProp, rawValue) shouldBe boolProp.copy(default = JsonPrimitive(expected))
-    }
-
-    @Test
-    fun `setDefaultValue falls back to the raw string when it does not parse as the target type`() {
-        val numProp = NumericPropertyDefinition(type = listOf("integer"))
-        setDefaultValue(numProp, "not-a-number") shouldBe numProp.copy(default = JsonPrimitive("not-a-number"))
     }
 
     private fun stringProperty(defaultValue: Any? = null, isConstant: Boolean = false): Property =

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspIntrospectionContext.kt
@@ -268,17 +268,24 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         val id = decl.typeId()
 
         return namedRef(type, id, nullable) {
-            val entries =
+            val constants =
                 decl.declarations
                     .filterIsInstance<KSClassDeclaration>()
                     .filter { it.classKind == com.google.devtools.ksp.symbol.ClassKind.ENUM_ENTRY }
-                    .map { entry -> extractNameOverride(entry) ?: entry.simpleName.asString() }
                     .toList()
+            var defaultValue: String? = null
+            val entries =
+                constants.map { entry ->
+                    val entryName = extractNameOverride(entry) ?: entry.simpleName.asString()
+                    if (defaultValue == null && entry.isEnumDefaultAnnotated()) defaultValue = entryName
+                    entryName
+                }
 
             val nameOverride = extractNameOverride(decl)
             EnumNode(
                 name = nameOverride ?: decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
                 entries = entries,
+                defaultValue = defaultValue,
                 description = extractDescription(decl) { decl.descriptionFromKdoc() },
             )
         }
@@ -333,10 +340,11 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 type: TypeRef,
                 description: String?,
                 hasDefaultValue: Boolean,
+                defaultValue: String? = null,
                 isConstant: Boolean = false,
             ) {
                 if (!hasDefaultValue || isConstant) required += name
-                props += createProperty(name, type, description, hasDefaultValue, isConstant)
+                props += createProperty(name, type, description, hasDefaultValue, defaultValue, isConstant)
                 processedKotlinNames += kotlinName
             }
 
@@ -368,17 +376,19 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         resolvedType: KSType,
         nativeHasDefault: Boolean,
         vararg annotationSources: KSAnnotated?,
-    ): Pair<TypeRef, Boolean> {
+    ): Triple<TypeRef, Boolean, String?> {
         val nullableAnnotated = annotationSources.any { it?.isNullableAnnotated() == true }
         val optionalAnnotated = annotationSources.any { it?.isOptionalAnnotated() == true }
+        val defaultValue = annotationSources.firstNotNullOfOrNull { it?.let(::extractDefaultValueOverride) }
         val typeRef = toRef(resolvedType).let { if (nullableAnnotated) it.withNullable(true) else it }
-        val hasDefault = nativeHasDefault || resolvedType.isOptionalByTypeName() || optionalAnnotated
-        return typeRef to hasDefault
+        val hasDefault =
+            nativeHasDefault || resolvedType.isOptionalByTypeName() || optionalAnnotated || defaultValue != null
+        return Triple(typeRef, hasDefault, defaultValue)
     }
 
     private fun extractConstructorOrProperties(
         decl: KSClassDeclaration,
-        addProperty: (String, String, TypeRef, String?, Boolean) -> Unit,
+        addProperty: (String, String, TypeRef, String?, Boolean, String?) -> Unit,
     ) {
         val declaredProperties = decl.getDeclaredProperties().associateBy { it.simpleName.asString() }
         // Prefer primary constructor parameters for data classes; fall back to public properties
@@ -392,7 +402,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 val propertyName =
                     extractNameOverride(p) ?: property?.let { extractNameOverride(it) } ?: kotlinName
                 val description = extractConstructorParamDescription(p, kotlinName, decl.docString, property)
-                val (typeRef, hasDefault) =
+                val (typeRef, hasDefault, defaultValue) =
                     resolvePropertyTypeAndOptionality(
                         p.type.resolve(),
                         p.hasDefault,
@@ -400,7 +410,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                         property,
                         property?.getter,
                     )
-                addProperty(kotlinName, propertyName, typeRef, description, hasDefault)
+                addProperty(kotlinName, propertyName, typeRef, description, hasDefault, defaultValue)
             }
         } else {
             declaredProperties.values
@@ -416,14 +426,14 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                             kdocTagName = "property",
                             elementKdocFallback = { prop.descriptionFromKdoc() },
                         )
-                    val (typeRef, hasDefault) =
+                    val (typeRef, hasDefault, defaultValue) =
                         resolvePropertyTypeAndOptionality(
                             prop.type.resolve(),
                             nativeHasDefault = false,
                             prop,
                             prop.getter,
                         )
-                    addProperty(kotlinName, propertyName, typeRef, description, hasDefault)
+                    addProperty(kotlinName, propertyName, typeRef, description, hasDefault, defaultValue)
                 }
         }
     }
@@ -431,7 +441,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
     private fun extractInheritedSealedProperties(
         decl: KSClassDeclaration,
         processedKotlinNames: Set<String>,
-        addProperty: (String, String, TypeRef, String?, Boolean, Boolean) -> Unit,
+        addProperty: (String, String, TypeRef, String?, Boolean, String?, Boolean) -> Unit,
     ) {
         // Add inherited properties from sealed parents that weren't in the constructor
         val sealedParents =
@@ -468,7 +478,7 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                         kdocTagName = "property",
                         elementKdocFallback = { effectiveProp.descriptionFromKdoc() },
                     )
-                val (typeRef, _) =
+                val (typeRef, _, _) =
                     resolvePropertyTypeAndOptionality(
                         effectiveProp.type.resolve(),
                         nativeHasDefault = true,
@@ -483,7 +493,8 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                     typeRef,
                     description,
                     true, // Fixed value in the subclass
-                    false, // KSP cannot get the value
+                    null, // KSP cannot get the value
+                    false, // isConstant: not marked const since the value can't be extracted
                 )
             }
         }

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspUtils.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/KspUtils.kt
@@ -147,14 +147,17 @@ internal fun extractConstructorParamDescription(
  * @param type Property type reference
  * @param description Property description (from annotations or KDoc)
  * @param hasDefaultValue Whether the property has a default value
+ * @param defaultValue The property's default value, if known. KSP cannot extract a Kotlin
+ *   default-value expression at compile-time, so this is only ever populated from an
+ *   annotation (e.g. `@JsonProperty(defaultValue = "...")`).
  * @param isConstant Whether the property is constant (fixed value)
- * @return Property instance with defaultValue set to null (KSP limitation)
  */
 internal fun createProperty(
     name: String,
     type: TypeRef,
     description: String?,
     hasDefaultValue: Boolean,
+    defaultValue: String? = null,
     isConstant: Boolean = false,
 ): Property =
     Property(
@@ -162,6 +165,6 @@ internal fun createProperty(
         type = type,
         description = description,
         hasDefaultValue = hasDefaultValue,
-        defaultValue = null, // KSP cannot extract default values at compile-time
+        defaultValue = defaultValue,
         isConstant = isConstant,
     )

--- a/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/defaultValues.kt
+++ b/kt-schema-ksp/src/main/kotlin/me/kpavlov/kt/schema/ksp/ir/defaultValues.kt
@@ -1,0 +1,53 @@
+package me.kpavlov.kt.schema.ksp.ir
+
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import me.kpavlov.kt.schema.generator.core.ir.Introspections
+
+/**
+ * Checks whether the symbol is annotated with a recognized enum-default-value marker
+ * (e.g. `@JsonEnumDefaultValue`), placed on a single enum constant.
+ *
+ * Recognition is delegated to [Introspections.isEnumDefaultAnnotation], which performs
+ * matching against a configurable set loaded from `kt-schema.properties`.
+ *
+ * @return `true` if any annotation on this symbol is recognized as an enum-default-value marker
+ */
+internal fun KSAnnotated.isEnumDefaultAnnotated(): Boolean =
+    annotations.any { annotation ->
+        val declaration = annotation.annotationType.resolve().declaration
+        val simpleName = declaration.simpleName.asString()
+        val qualifiedName = declaration.qualifiedName?.asString()
+        Introspections.isEnumDefaultAnnotation(simpleName, qualifiedName)
+    }
+
+/**
+ * Retrieves the default-value override from the annotation, if available (e.g. from
+ * `@JsonProperty(defaultValue = "...")`).
+ *
+ * @return The default value extracted from the annotation or null if not a default-value annotation.
+ */
+internal fun KSAnnotation.defaultValueOrNull(): String? {
+    val declaration = annotationType.resolve().declaration
+    val simpleName = declaration.simpleName.asString()
+    val qualifiedName = declaration.qualifiedName?.asString()
+
+    val args: List<Pair<String, Any?>> =
+        arguments.mapNotNull {
+            val name = it.name?.asString() ?: return@mapNotNull null
+            name to it.value
+        }
+    return Introspections.getDefaultValueFromAnnotation(
+        simpleName = simpleName,
+        qualifiedName = qualifiedName,
+        annotationArguments = args,
+    )
+}
+
+/**
+ * Extracts a default-value override from an annotated element's own annotations.
+ *
+ * @see [defaultValueOrNull]
+ */
+internal fun extractDefaultValueOverride(annotated: KSAnnotated): String? =
+    annotated.annotations.firstNotNullOfOrNull { it.defaultValueOrNull() }


### PR DESCRIPTION
## Description

Populates EnumNode.defaultValue from `@JsonEnumDefaultValue` (always shown on the enum's own `$defs` schema) and Property.defaultValue from `@JsonProperty(defaultValue = "...")` in APT, KSP, and Reflection, closing the gap for front ends that can't evaluate a real Kotlin default-value expression at compile time. Both are recognized via the same configurable kt-schema.properties mechanism as existing description/name annotations.

Also fixes `setDefaultValue()` not handling `ReferencePropertyDefinition`/ `OneOfPropertyDefinition`, which silently dropped defaults on enum-typed properties even when a real value was already known (e.g. via reflection), and extracts the duplicated const/default-application logic in both JSON transformers into a shared `applyDefaultOrConst` helper.

kotlinx-serialization is intentionally not wired up: SerialDescriptor only preserves annotations meta-annotated with `@SerialInfo`, so a plain Jackson annotation is invisible to it.

Related to #74 
