### PR TITLE
feat(apt): support BigInteger and BigDecimal numeric types

### DIFF
--- a/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Payment.java
+++ b/apt-integration-tests/src/main/java/me/kpavlov/kt/schema/apt/integration/type/Payment.java
@@ -1,0 +1,19 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Test model to verify BigInteger and BigDecimal schema generation in APT.
+ */
+@JsonClassDescription("A payment with BigInteger quantity and BigDecimal amount.")
+public record Payment(
+    @JsonPropertyDescription("Quantity of items")
+    BigInteger quantity,
+    @JsonPropertyDescription("Total amount of payment")
+    BigDecimal amount
+) {
+}

--- a/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PaymentSchemaTest.java
+++ b/apt-integration-tests/src/test/java/me/kpavlov/kt/schema/apt/integration/type/PaymentSchemaTest.java
@@ -1,0 +1,53 @@
+package me.kpavlov.kt.schema.apt.integration.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/**
+ * Verifies the kt-schema-apt processor generates a JSON Schema resource for a Java
+ * record containing BigInteger and BigDecimal fields.
+ */
+class PaymentSchemaTest {
+
+    private static final String RESOURCE_PATH =
+            "META-INF/kt-schema/schemas/me/kpavlov/kt/schema/apt/integration/type/Payment.json";
+
+    @Test
+    void shouldGenerateCompleteSchemaWithBigIntegerAndBigDecimal() throws IOException {
+        // language=json
+        assertThatJson(readGeneratedSchema()).isEqualTo("""
+                {
+                  "$id": "me.kpavlov.kt.schema.apt.integration.type.Payment",
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "quantity": {
+                      "type": "integer",
+                      "description": "Quantity of items"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "description": "Total amount of payment"
+                    }
+                  },
+                  "required": ["quantity", "amount"],
+                  "additionalProperties": false,
+                  "description": "A payment with BigInteger quantity and BigDecimal amount."
+                }
+                """);
+    }
+
+    private static String readGeneratedSchema() throws IOException {
+        try (InputStream input = PaymentSchemaTest.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            if (input == null) {
+                throw new IllegalStateException("Missing generated schema resource: " + RESOURCE_PATH);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
+++ b/kt-schema-apt/src/main/kotlin/me/kpavlov/kt/schema/apt/ir/AptIntrospectionContext.kt
@@ -129,9 +129,9 @@ internal class AptIntrospectionContext(
             "java.lang.String" -> PrimitiveKind.STRING
             "java.lang.Boolean" -> PrimitiveKind.BOOLEAN
             "java.lang.Integer", "java.lang.Short", "java.lang.Byte" -> PrimitiveKind.INT
-            "java.lang.Long" -> PrimitiveKind.LONG
+            "java.lang.Long", "java.math.BigInteger" -> PrimitiveKind.LONG
             "java.lang.Float" -> PrimitiveKind.FLOAT
-            "java.lang.Double" -> PrimitiveKind.DOUBLE
+            "java.lang.Double", "java.math.BigDecimal" -> PrimitiveKind.DOUBLE
             "java.lang.Character" -> PrimitiveKind.STRING
             else -> null
         }

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/JsonSchemaProcessorTest.kt
@@ -1486,6 +1486,43 @@ class JsonSchemaProcessorTest {
             ),
         )
 
+    @Test
+    fun `should generate schema for record with BigInteger and BigDecimal`(
+        @TempDir tempDir: Path,
+    ) {
+        // language=java
+        val source = """
+            package com.example;
+
+            import java.math.BigDecimal;
+            import java.math.BigInteger;
+            import me.kpavlov.kt.schema.Schema;
+
+            @Schema
+            public record Payment(
+                BigInteger quantity,
+                BigDecimal amount
+            ) {}
+        """.trimIndent()
+
+        val outputDir = compile(source, tempDir)
+
+        // language=json
+        outputDir.readSchema("com.example.Payment") shouldEqualJson $$"""
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "com.example.Payment",
+                "type": "object",
+                "properties": {
+                    "quantity": { "type": "integer" },
+                    "amount": { "type": "number" }
+                },
+                "additionalProperties": false,
+                "required": ["quantity", "amount"]
+            }
+        """.trimIndent()
+    }
+
     //endregion
 
     //region compiler helpers

--- a/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
+++ b/kt-schema-apt/src/test/kotlin/me/kpavlov/kt/schema/apt/ir/AptClassIntrospectorTest.kt
@@ -95,6 +95,8 @@ class AptClassIntrospectorTest {
         "java.lang.Double, DOUBLE",
         "java.lang.Boolean, BOOLEAN",
         "java.lang.Character, STRING",
+        "java.math.BigInteger, LONG",
+        "java.math.BigDecimal, DOUBLE",
     )
     fun `should map java scalar types to primitive kinds`(
         javaType: String,


### PR DESCRIPTION
## Summary

Extends `AptIntrospectionContext` to recognize `java.math.BigInteger` and `java.math.BigDecimal` as numeric scalar types:
- `java.math.BigInteger` maps to IR `PrimitiveKind.LONG` (`"type": "integer"` in emitted JSON Schema).
- `java.math.BigDecimal` maps to IR `PrimitiveKind.DOUBLE` (`"type": "number"` in emitted JSON Schema).
- Preserves all existing Java primitive, boxed, and String mappings.

Closes #113

## Validation

- Added unit and processor test coverage in `kt-schema-apt` (`AptClassIntrospectorTest` and `JsonSchemaProcessorTest`).
- Added end-to-end integration test in `apt-integration-tests` (`Payment` record model and `PaymentSchemaTest`).
- Ran test and validation suite:
  - `./gradlew :kt-schema-apt:test :apt-integration-tests:test` (107/107 passed)
  - `./gradlew check` (256 tasks passed)
  - `./gradlew detekt checkLegacyAbi` passed cleanly